### PR TITLE
Simplify defaults and cleanup setups

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ apply plugin: "com.slack.keeper"
 There are optional configurations available via the `keeper` extension, mostly just for debugging
 purposes or setting a custom R8 version.
 
-```
+```groovy
 keeper {
   /**
    * R8 version, only used for PrintUses and does _not_ override the R8 version used for
@@ -52,6 +52,17 @@ keeper {
    * Example: `listOf("-Xdebug", "-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y")`
    */
   r8JvmArgs = []
+}
+```
+
+Keeper uses R8's `PrintUses` CLI under the hood for rules inference. By default it uses R8 version
+`1.6.53`. If you want to customize what version is used, you can specify the dependency via the
+`keeperR8` configuration. Note that these must be tags from R8's
+[`r8-releases/raw`](https://storage.googleapis.com/r8-releases/raw) maven repo.
+
+```groovy
+dependencies {
+  keeperR8 "com.android.tools:r8:x.y.z"
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,35 +21,28 @@ vars are described [here](https://github.com/slackhq/keeper/blob/master/.github/
 
 ## Installation
 
-Apply keeper _after_ the `android {}` block in your application's build.gradle file and configure
-via the `keeper {}` extension.
+Keeper is distributed via Maven Central. Apply the keeper Gradle plugin in your application's
+build.gradle.
 
 ```groovy
 buildscript {
-  repositories {
-    mavenCentral()
-    // ...
-  }
-
   dependencies {
-    // ...
     classpath "com.slack.keeper:keeper:x.y.z"
   }
-
-}
-
-android {
-  // ...
 }
 
 apply plugin: "com.slack.keeper"
+```
 
-// Optional configuration
+There are optional configurations available via the `keeper` extension, mostly just for debugging
+purposes or setting a custom R8 version.
+
+```
 keeper {
-  /** Controls whether or not to enable Keeper. Default is true. */
-  enabled = true
-
-  /** R8 version. Must be a tag. Default defined below. */
+  /**
+   * R8 version, only used for PrintUses and does _not_ override the R8 version used for
+   * minification. Must be a tag. Default defined below.
+   */
   r8Version = "1.6.53"
 
   /**

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,22 +43,18 @@ android {
 }
 
 apply plugin: "com.slack.keeper"
+
+// Optional configuration
 keeper {
-  /**
-   * The name of the androidTest variant to infer for. This should include the "AndroidTest"
-   * suffix. Required.
-   */
-  androidTestVariant = "yourAndroidTestVariantHere" // Required
+  /** Controls whether or not to enable Keeper. Default is true. */
+  enabled = true
 
-  /** The name of the application variant to infer for. Required. */
-  appVariant = "yourReleaseVariantHere"
-
-  /** R8 version. Must be a tag. Optional, default defined below. */
+  /** R8 version. Must be a tag. Default defined below. */
   r8Version = "1.6.53"
 
   /**
    * Optional custom jvm arguments to pass into the R8 `PrintUses` execution. Useful if you want
-   * to enable debugging in R8. Optional, default is empty.
+   * to enable debugging in R8. Default is empty.
    *
    * Example: `listOf("-Xdebug", "-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y")`
    */
@@ -66,37 +62,75 @@ keeper {
 }
 ```
 
+Snapshots of the development version are available in [Sonatype's `snapshots` repository][snapshots].
+
 ### Dynamic Configuration
 
-If you want to dynamically configure this, one approach we use internally is to define a `buildVariant`
-gradle property and use its value to gate application of this plugin and which variant to use.
+As mentioned above, Keeper's default behavior with no configuration will enable it for _all_
+androidTest variants. This may not be what you want for your actual production builds that you plan
+to distribute.
+
+Normally, your app variant's minification task doesn't depend on compilation of its corresponding
+`androidTest` variant. This means you can call `assembleRelease` and `assembleAndroidTestRelease`
+ won't inherently run. Keeper, however, changes this since it requires the compiled androidTest
+ sources in order to correctly infer how they use APIs in the app variant. For a production build,
+you likely _do_ want these "test-only" APIs removed if possible though. There are a few patterns to
+better control this behavior via Gradle property.
+
+Let's assume an example command to build a production app with custom property `productionBuild`.
+
+```bash
+./gradlew :myapp:assembleRelease -PproductionBuild=true
+```
+
+#### Use the `testBuildType` option
+
+If you avoid setting your `testBuildType` to your "release" build type in a production build, then
+Keeper won't configure your release artifact to depend on test sources since your release variant
+would no longer be the `testedVariant` of any `androidTest` variants.
+
+This is the *recommended* solution.
 
 ```groovy
-if (project.hasProperty("buildVariant")) {
-  String buildVariant = project.getProperty("buildVariant")
-  apply plugin: 'com.slack.keeper
+android {
+  // ...
 
-  keeper {
-    androidTestVariant = "${buildVariant}AndroidTest"
-    appVariant = buildVariant
+  if (hasProperty("productionBuild")) {
+    testBuildType = "debug"
+  } else {
+    // You would have had to have been doing something like this anyway if you're using Keeper!
+    testBuildType = "release"
   }
 }
 ```
 
-Snapshots of the development version are available in [Sonatype's `snapshots` repository][snapshots].
+#### Avoid applying the plugin entirely
+
+This is probably the simplest approach, but not as dynamic as controlling the `testBuildType`.
+
+```groovy
+if (!hasProperty("productionBuild")) {
+  apply plugin: 'com.slack.keeper
+}
+```
+
+### <your build here>
+
+Everyone's project is different, so you should do whatever works for you! We're open to suggestions
+of better ways to support configuration for this, so please do file issues if you have any proposals.
 
 ## Under the hood
 
 The general logic flow:
 - Create a custom `r8` configuration for the R8 dependency.
-- Register three jar tasks. One for all the classes in the app variant, one for all the classes in
-  the androidTest variant, and one copy of the compiled android.jar for classpath linking. This
-  will use their variant-provided `JavaCompile` tasks and `KotlinCompile` tasks if available.
-- Register a [`inferAndroidTestUsage`](https://github.com/slackhq/keeper/blob/master/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/InferAndroidTestKeepRules.kt)
+- Register two jar tasks per `androidTest` variant. One for all the classes in its target `testedVariant`
+  and one for all the classes in the androidTest variant itself. This will use their variant-provided
+  `JavaCompile` tasks and `KotlinCompile` tasks if available.
+- Register a [`infer${androidTestVariant}UsageForKeeper`](https://github.com/slackhq/keeper/blob/master/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/InferAndroidTestKeepRules.kt)
   task that plugs the two aforementioned jars into R8's `PrintUses` CLI and outputs the inferred
   proguard rules into a new intermediate `.pro` file.
-- Finally - the generated file is wired in to Proguard/R8 via private `ProguardConfigurable` API.
-  This works by looking for the relevant `TransformTask` that uses it.
+- Finally - the generated file is wired in to Proguard/R8 via private task APIs and setting their
+  `configurationFiles` to include our generated one.
 
 Appropriate task dependencies (via inputs/outputs, not `dependsOn`) are set up, so this is
 automatically run as part of the target app variant's full minified APK.

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/AgpVersionHandler.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/AgpVersionHandler.kt
@@ -105,11 +105,14 @@ class Agp35xPatcher : AgpVersionHandler {
   override fun applyGeneratedRules(project: Project, appVariant: String,
       prop: Provider<Directory>) {
     val targetName = interpolatedTaskName(expectedMinifier(project), appVariant.capitalize(Locale.US))
-    project.tasks.withType<TransformTask>().configureEach {
-      if (name == targetName && proguardConfigurable.isInstance(transform)) {
-        project.logger.debug("$TAG: Patching task '$name' with inferred androidTest proguard rules")
-        (configurationFilesField.get(proguardConfigurable.cast(transform)) as ConfigurableFileCollection)
-            .from(prop)
+    // Have to run the proguard task configuration in afterEvaluate because the transform property isn't set until later
+    project.afterEvaluate {
+      project.tasks.withType<TransformTask>().configureEach {
+        if (name == targetName && proguardConfigurable.isInstance(transform)) {
+          project.logger.debug("$TAG: Patching task '$name' with inferred androidTest proguard rules")
+          (configurationFilesField.get(proguardConfigurable.cast(transform)) as ConfigurableFileCollection)
+              .from(prop)
+        }
       }
     }
   }

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/AgpVersionHandler.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/AgpVersionHandler.kt
@@ -77,7 +77,7 @@ interface AgpVersionHandler {
   /** Patches the provided [prop] into the target available proguard task. */
   fun applyGeneratedRules(
       project: Project,
-      extension: KeeperExtension,
+      appVariant: String,
       prop: Provider<Directory>
   )
 }
@@ -102,9 +102,9 @@ class Agp35xPatcher : AgpVersionHandler {
     return "transformClassesAndResourcesWith${minifier}For${variant}"
   }
 
-  override fun applyGeneratedRules(project: Project, extension: KeeperExtension,
+  override fun applyGeneratedRules(project: Project, appVariant: String,
       prop: Provider<Directory>) {
-    val targetName = interpolatedTaskName(expectedMinifier(project), extension.appVariant.capitalize(Locale.US))
+    val targetName = interpolatedTaskName(expectedMinifier(project), appVariant.capitalize(Locale.US))
     project.tasks.withType<TransformTask>().configureEach {
       if (name == targetName && proguardConfigurable.isInstance(transform)) {
         project.logger.debug("$TAG: Patching task '$name' with inferred androidTest proguard rules")
@@ -133,9 +133,9 @@ class Agp36xPatcher : AgpVersionHandler {
     return "minify${variant}With${minifier}"
   }
 
-  override fun applyGeneratedRules(project: Project, extension: KeeperExtension,
+  override fun applyGeneratedRules(project: Project, appVariant: String,
       prop: Provider<Directory>) {
-    val targetName = interpolatedTaskName(expectedMinifier(project), extension.appVariant.capitalize(Locale.US))
+    val targetName = interpolatedTaskName(expectedMinifier(project), appVariant.capitalize(Locale.US))
     project.tasks.withType(proguardConfigurableTask).configureEach {
       // Names are minify{variant}WithProguard
       if (name == targetName) {

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/InferAndroidTestKeepRules.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/InferAndroidTestKeepRules.kt
@@ -17,8 +17,10 @@
 package com.slack.keeper
 
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
@@ -26,7 +28,6 @@ import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.jvm.tasks.Jar
-import java.io.File
 
 /**
  * Generates proguard keep rules from the generated [androidTestJar] and [appJar] tasks,
@@ -90,7 +91,7 @@ abstract class InferAndroidTestKeepRules : JavaExec() {
     operator fun invoke(
         androidTestJarProvider: TaskProvider<out Jar>,
         releaseClassesJarProvider: TaskProvider<out Jar>,
-        androidJar: File,
+        androidJar: Provider<RegularFile>,
         extensionJvmArgs: ListProperty<String>,
         r8Configuration: Configuration
     ): InferAndroidTestKeepRules.() -> Unit = {

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperExtension.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperExtension.kt
@@ -25,16 +25,6 @@ import javax.inject.Inject
 
 /** Configuration for the [InferAndroidTestKeepRules]. */
 open class KeeperExtension @Inject constructor(objects: ObjectFactory) {
-
-  /**
-   * The name of the androidTest variant to infer for. This should include the "AndroidTest"
-   * suffix. Required.
-   */
-  lateinit var androidTestVariant: String
-
-  /** The name of the application variant to infer for. Required. */
-  lateinit var appVariant: String
-
   /** R8 version. Can be a tag or sha. Default is 1.6.53. */
   val r8Version: Property<String> = objects.property()
 

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperExtension.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperExtension.kt
@@ -18,19 +18,11 @@ package com.slack.keeper
 
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
-import org.gradle.api.provider.Property
 import org.gradle.kotlin.dsl.listProperty
-import org.gradle.kotlin.dsl.property
 import javax.inject.Inject
 
 /** Configuration for the [InferAndroidTestKeepRules]. */
 open class KeeperExtension @Inject constructor(objects: ObjectFactory) {
-  /**
-   * R8 version, only used for PrintUses and does _not_ override the R8 version used for
-   * minification. Must be a tag. Default defined below.
-   */
-  val r8Version: Property<String> = objects.property()
-
   /**
    * Optional custom jvm arguments to pass into the R8 `PrintUses` execution. Useful if you want
    * to enable debugging in R8.

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperExtension.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperExtension.kt
@@ -25,7 +25,10 @@ import javax.inject.Inject
 
 /** Configuration for the [InferAndroidTestKeepRules]. */
 open class KeeperExtension @Inject constructor(objects: ObjectFactory) {
-  /** R8 version. Can be a tag or sha. Default is 1.6.53. */
+  /**
+   * R8 version, only used for PrintUses and does _not_ override the R8 version used for
+   * minification. Must be a tag. Default defined below.
+   */
   val r8Version: Property<String> = objects.property()
 
   /**

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperPlugin.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperPlugin.kt
@@ -100,14 +100,16 @@ class KeeperPlugin : Plugin<Project> {
 
         val appExtension = project.extensions.getByType<AppExtension>()
 
-        val compileSdkVersion = appExtension.compileSdkVersion ?: error(
-            "No compileSdkVersion found. Make sure to apply the keeper plugin after the android block in build.gradle.")
-        val androidJar =
-            File("${appExtension.sdkDirectory}/platforms/${compileSdkVersion}/android.jar").also {
-              check(it.exists()) {
-                "No android.jar found! Expected to find it at: $it"
-              }
+        val androidJarFileProvider = project.provider {
+          val compileSdkVersion = appExtension.compileSdkVersion
+              ?: error("No compileSdkVersion found")
+          File("${appExtension.sdkDirectory}/platforms/${compileSdkVersion}/android.jar").also {
+            check(it.exists()) {
+              "No android.jar found! Expected to find it at: $it"
             }
+          }
+        }
+        val androidJarRegularFileProvider = project.layout.file(androidJarFileProvider)
 
         // Have to run the proguard task configuration afterEvaluate because the transform property isn't set until later
         afterEvaluate {
@@ -124,7 +126,7 @@ class KeeperPlugin : Plugin<Project> {
                 InferAndroidTestKeepRules(
                     intermediateAndroidTestJar,
                     intermediateAppJar,
-                    androidJar,
+                    androidJarRegularFileProvider,
                     extension.r8JvmArgs,
                     r8Configuration
                 )

--- a/keeper-gradle-plugin/src/test/kotlin/com/slack/keeper/KeeperFunctionalTest.kt
+++ b/keeper-gradle-plugin/src/test/kotlin/com/slack/keeper/KeeperFunctionalTest.kt
@@ -159,7 +159,7 @@ class KeeperFunctionalTest(private val minifierType: MinifierType) {
         .forwardStdOutput(System.out.writer())
         .forwardStdError(System.err.writer())
         .withProjectDir(projectDir)
-        .withArguments("--stacktrace", "-x", "lint", *minifierType.gradleArgs, *args)
+        .withArguments("--stacktrace", "-x", "lintVitalRelease", *minifierType.gradleArgs, *args)
         .withPluginClasspath()
 //        .withDebug(true)
         .build()

--- a/keeper-gradle-plugin/src/test/kotlin/com/slack/keeper/KeeperFunctionalTest.kt
+++ b/keeper-gradle-plugin/src/test/kotlin/com/slack/keeper/KeeperFunctionalTest.kt
@@ -114,11 +114,11 @@ class KeeperFunctionalTest(private val minifierType: MinifierType) {
     val (projectDir, proguardConfigOutput) = prepareProject(temporaryFolder)
 
     val result = runGradle(projectDir, "assembleReleaseAndroidTest")
-    assertThat(result.resultOf("jarAndroidTestClassesForAndroidTestKeepRules")).isEqualTo(
+    assertThat(result.resultOf("jarReleaseAndroidTestClassesForKeeper")).isEqualTo(
         TaskOutcome.SUCCESS)
-    assertThat(result.resultOf("jarAppClassesForAndroidTestKeepRules")).isEqualTo(
+    assertThat(result.resultOf("jarReleaseClassesForKeeper")).isEqualTo(
         TaskOutcome.SUCCESS)
-    assertThat(result.resultOf("inferAndroidTestUsage")).isEqualTo(TaskOutcome.SUCCESS)
+    assertThat(result.resultOf("inferReleaseAndroidTestUsageForKeeper")).isEqualTo(TaskOutcome.SUCCESS)
 
     // Ensure the expected parameterized minifiers ran
     val agpVersion = AgpVersionHandler.getInstance()
@@ -259,10 +259,6 @@ private val BUILD_GRADLE_CONTENT = """
   }
 
   apply plugin: 'com.slack.keeper'
-  keeper {
-    androidTestVariant = "releaseAndroidTest"
-    appVariant = "release"
-  }
   
   dependencies {
     //noinspection DifferentStdlibGradleVersion

--- a/keeper-gradle-plugin/src/test/kotlin/com/slack/keeper/KeeperFunctionalTest.kt
+++ b/keeper-gradle-plugin/src/test/kotlin/com/slack/keeper/KeeperFunctionalTest.kt
@@ -230,6 +230,7 @@ private val BUILD_GRADLE_CONTENT = """
 
   apply plugin: 'com.android.application'
   apply plugin: 'org.jetbrains.kotlin.android'
+  apply plugin: 'com.slack.keeper'
 
   android {
     compileSdkVersion 29
@@ -257,8 +258,6 @@ private val BUILD_GRADLE_CONTENT = """
     mavenCentral()
     jcenter()
   }
-
-  apply plugin: 'com.slack.keeper'
   
   dependencies {
     //noinspection DifferentStdlibGradleVersion

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -16,6 +16,7 @@
 
 apply plugin: 'com.android.application'
 apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'com.slack.keeper'
 
 android {
   compileSdkVersion 29
@@ -41,12 +42,6 @@ android {
   }
 
   testBuildType = "release"
-}
-
-apply plugin: 'com.slack.keeper'
-keeper {
-  androidTestVariant = "releaseAndroidTest"
-  appVariant = "release"
 }
 
 dependencies {


### PR DESCRIPTION
This is the finishing touches on the API of the plugin. With this, the plugin is no longer ordering dependent and requires no configuration by default.

In fact - the only configuration remaining after this is just r8 controls, which have been tweaked to be a little more conventional.

Resolves #5 
Resolves #2 