### PR TITLE
Add variant filtering

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,7 +69,29 @@ if (!hasProperty("productionBuild")) {
 }
 ```
 
-##### <your build here>
+### Variant filter
+
+You can specify a `variantFilter` on the `keeper` extension and dynamically configure which variants
+Keeper operates on. This is nearly identical to the `android.variantFilter` API
+
+You can specify a `variantFilter` on the `keeper` extension and dynamically configure which variants
+Keeper operates on. This is nearly identical to AGP's native `variantFilter` API except that there
+is no `defaultConfig` property.
+
+**Note:** Variants with different `enabled` values will have to be compiled separately. This is common
+in most multi-variant projects anyway, but something to be aware of.
+
+```groovy
+keeper {
+  variantFilter {
+    if (name == "variantThatShouldTotallyBeIgnored") {
+      setIgnore(true)
+    }
+  }
+}
+```
+
+### <your build here>
 
 Everyone's project is different, so you should do whatever works for you! We're open to suggestions
 of better ways to support configuration for this, so please do file issues if you have any proposals.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,9 +72,6 @@ if (!hasProperty("productionBuild")) {
 ### Variant filter
 
 You can specify a `variantFilter` on the `keeper` extension and dynamically configure which variants
-Keeper operates on. This is nearly identical to the `android.variantFilter` API
-
-You can specify a `variantFilter` on the `keeper` extension and dynamically configure which variants
 Keeper operates on. This is nearly identical to AGP's native `variantFilter` API except that there
 is no `defaultConfig` property.
 

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperExtension.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperExtension.kt
@@ -16,6 +16,9 @@
 
 package com.slack.keeper
 
+import com.android.builder.model.BuildType
+import com.android.builder.model.ProductFlavor
+import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.kotlin.dsl.listProperty
@@ -23,6 +26,18 @@ import javax.inject.Inject
 
 /** Configuration for the [InferAndroidTestKeepRules]. */
 open class KeeperExtension @Inject constructor(objects: ObjectFactory) {
+  internal var _variantFilter: Action<VariantFilter>? = null
+
+  /**
+   * Applies a variant filter for Android. Note that the variant tested is the _app_ variant, not
+   * the test variant.
+   *
+   * @param action the configure action for the [VariantFilter]
+   */
+  fun variantFilter(action: Action<VariantFilter>) {
+    this._variantFilter = action
+  }
+
   /**
    * Optional custom jvm arguments to pass into the R8 `PrintUses` execution. Useful if you want
    * to enable debugging in R8.
@@ -30,4 +45,27 @@ open class KeeperExtension @Inject constructor(objects: ObjectFactory) {
    * Example: `listOf("-Xdebug", "-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y")`
    */
   val r8JvmArgs: ListProperty<String> = objects.listProperty()
+}
+
+
+interface VariantFilter {
+  /**
+   * Indicate whether or not to ignore this particular variant. Default is false.
+   */
+  fun setIgnore(ignore: Boolean)
+
+  /**
+   * Returns the Build Type.
+   */
+  val buildType: BuildType
+
+  /**
+   * Returns the list of flavors, or an empty list.
+   */
+  val flavors: List<ProductFlavor>
+
+  /**
+   * Returns the unique variant name.
+   */
+  val name: String
 }

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperPlugin.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperPlugin.kt
@@ -38,7 +38,6 @@ import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.repositories
-import org.jetbrains.kotlin.gradle.internal.KaptVariantData
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.File
 import java.util.Locale
@@ -287,7 +286,6 @@ private fun unwrapTestedVariant(variantData: Any?): BaseVariant? {
         else -> variantData
       }
     }
-    is KaptVariantData<*> -> unwrapTestedVariant(variantData.variantData)
     else -> null
   }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -36,12 +36,35 @@ android {
   buildTypes {
     release {
       minifyEnabled = true
-      signingConfig = buildTypes.debug.signingConfig
+      signingConfig = signingConfigs.debug
       proguardFiles getDefaultProguardFile('proguard-android.txt')
+    }
+    staging {
+      initWith release
+      matchingFallbacks = ['release']
+    }
+  }
+
+  flavorDimensions "environment"
+  productFlavors {
+    internal {
+      dimension "environment"
+      applicationIdSuffix ".internal"
+      versionNameSuffix "-internal"
+    }
+
+    external {
+      dimension "environment"
     }
   }
 
   testBuildType = "release"
+}
+
+keeper {
+  variantFilter {
+    setIgnore(name == "externalRelease")
+  }
 }
 
 dependencies {


### PR DESCRIPTION
Resolves #15 

Now you can do something like this to explicitly filter out certain variants

```gradle
keeper {
  variantFilter {
    setIgnored(name == "variantThatShouldTotallyBeIgnored")
  }
}
```

~~This works based on eyeballing, now just need to add a test to lock it down~~