### PR TITLE
Move to AGP 3.6.0 stable + remove 3.5.x support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,7 @@ jobs:
     strategy:
       matrix:
         ci_java_version: [1.8]
-        # 4.0.0-alpha09 has a regression with transitive project dependencies, omitted pending further investigation
-        ci_agp_version: [3.6.0]
+        ci_agp_version: [3.6.0, 4.0.0-beta01]
         job: [instrumentation, plugin]
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         ci_java_version: [1.8]
         # 4.0.0-alpha09 has a regression with transitive project dependencies, omitted pending further investigation
-        ci_agp_version: [3.5.3, 3.6.0-rc02]
+        ci_agp_version: [3.6.0]
         job: [instrumentation, plugin]
     steps:
       - name: Checkout
@@ -67,11 +67,11 @@ jobs:
           path: build-reports.zip
       - name: Reclaim memory
         run: ./gradlew --stop && jps|grep -E 'KotlinCompileDaemon|GradleDaemon'| awk '{print $1}'| xargs kill -9 || true
-        if: success() && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && matrix.ci_java_version == '1.8' && matrix.ci_agp_version == '3.5.3' && matrix.job == 'plugin'
+        if: success() && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && matrix.ci_java_version == '1.8' && matrix.ci_agp_version == '3.6.0' && matrix.job == 'plugin'
       - name: Upload snapshot (master only)
         env:
           ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SonatypeUsername }}
           ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: ${{ secrets.SonatypePassword }}
         run: |
           ./publish.sh --snapshot
-        if: success() && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && matrix.ci_java_version == '1.8' && matrix.ci_agp_version == '3.5.3' && matrix.job == 'plugin'
+        if: success() && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && matrix.ci_java_version == '1.8' && matrix.ci_agp_version == '3.6.0' && matrix.job == 'plugin'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         ci_java_version: [1.8]
-        ci_agp_version: [3.6.0, 4.0.0-beta01]
+        ci_agp_version: [3.6.0]
         job: [instrumentation, plugin]
     steps:
       - name: Checkout

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         jcenter()
     }
 
-    String defaultAgpVersion = "3.5.3"
+    String defaultAgpVersion = "3.6.0"
     String agpVersion = findProperty("keeperTest.agpVersion")?.toString() ?: defaultAgpVersion
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61"

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ build type that you test against is controlled by the `testBuildType` flag,  whi
 This is a workaround until AGP supports this: https://issuetracker.google.com/issues/126429384.
 
 **Note:** Keeper uses private APIs from AGP and could break between releases. It is currently
-tested against AGP version 3.6.0 (or whatever `ci_agp_version` env
+tested against AGP versions 3.6.0 and 4.0.0-beta01 (or whatever `ci_agp_version` env
 vars are described [here](https://github.com/slackhq/keeper/blob/master/.github/workflows/ci.yml).
 
 ## Installation

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ build type that you test against is controlled by the `testBuildType` flag,  whi
 This is a workaround until AGP supports this: https://issuetracker.google.com/issues/126429384.
 
 **Note:** Keeper uses private APIs from AGP and could break between releases. It is currently
-tested against AGP versions 3.5.3 and 3.6.0-rc02 (or whatever `ci_agp_version` env
+tested against AGP version 3.6.0 (or whatever `ci_agp_version` env
 vars are described [here](https://github.com/slackhq/keeper/blob/master/.github/workflows/ci.yml).
 
 ## Installation
@@ -37,6 +37,8 @@ apply plugin: "com.slack.keeper"
 ```
 
 Optional configuration options can be found on the [Configuration page](configuration.md).
+
+As of 0.3.0, Keeper requires at least AGP 3.6.0.
 
 Snapshots of the development version are available in [Sonatype's `snapshots` repository][snapshots].
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ build type that you test against is controlled by the `testBuildType` flag,  whi
 This is a workaround until AGP supports this: https://issuetracker.google.com/issues/126429384.
 
 **Note:** Keeper uses private APIs from AGP and could break between releases. It is currently
-tested against AGP versions 3.6.0 and 4.0.0-beta01 (or whatever `ci_agp_version` env
+tested against AGP version 3.6.0 (or whatever `ci_agp_version` env
 vars are described [here](https://github.com/slackhq/keeper/blob/master/.github/workflows/ci.yml).
 
 ## Installation

--- a/keeper-gradle-plugin/build.gradle.kts
+++ b/keeper-gradle-plugin/build.gradle.kts
@@ -70,7 +70,7 @@ mavenPublish {
     useLegacyMode = true
 }
 
-val defaultAgpVersion = "3.5.3"
+val defaultAgpVersion = "3.6.0"
 val agpVersion = findProperty("keeperTest.agpVersion")?.toString() ?: defaultAgpVersion
 
 // See https://github.com/slackhq/keeper/pull/11#issuecomment-579544375 for context

--- a/keeper-gradle-plugin/src/test/kotlin/com/slack/keeper/KeeperFunctionalTest.kt
+++ b/keeper-gradle-plugin/src/test/kotlin/com/slack/keeper/KeeperFunctionalTest.kt
@@ -263,7 +263,7 @@ private fun buildGradleFile(
 
     dependencies {
       // Note: this version doesn't really matter, the plugin's version will override it in the test
-      classpath "com.android.tools.build:gradle:3.5.3"
+      classpath "com.android.tools.build:gradle:3.6.0"
       classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61"
     }
   }


### PR DESCRIPTION
We may add 3.5.x support again, but only as a recipe for a service loader approach if we get feedback asking for it. This also lets us add back 4.x betas to the test matrix