### PR TITLE
Switch to Zipflinger

### DIFF
--- a/keeper-gradle-plugin/build.gradle.kts
+++ b/keeper-gradle-plugin/build.gradle.kts
@@ -79,6 +79,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.3.61")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin-api:1.3.61")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61")
+    implementation("com.android:zipflinger:3.6.0")
     if (releaseMode) {
         compileOnly("com.android.tools.build:gradle:$defaultAgpVersion")
     } else {

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/InferAndroidTestKeepRules.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/InferAndroidTestKeepRules.kt
@@ -28,7 +28,6 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskProvider
-import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.repositories
 import java.util.Locale
 
@@ -93,7 +92,7 @@ abstract class InferAndroidTestKeepRules : JavaExec() {
     @Suppress("UNCHECKED_CAST")
     operator fun invoke(
         variantName: String,
-        androidTestJarProvider: TaskProvider<out Jar>,
+        androidTestJarProvider: TaskProvider<out AndroidTestVariantClasspathJar>,
         releaseClassesJarProvider: TaskProvider<out VariantClasspathJar>,
         androidJar: Provider<RegularFile>,
         automaticallyAddR8Repo: Property<Boolean>,
@@ -122,7 +121,9 @@ abstract class InferAndroidTestKeepRules : JavaExec() {
       jvmArgsProperty.set(extensionJvmArgs)
       workingDir = project.projectDir
       outputProguardRules.set(
-          project.layout.buildDirectory.file("${KeeperPlugin.INTERMEDIATES_DIR}/inferred${variantName.capitalize(Locale.US)}KeepRules.pro"))
+          project.layout.buildDirectory.file(
+              "${KeeperPlugin.INTERMEDIATES_DIR}/inferred${variantName.capitalize(
+                  Locale.US)}KeepRules.pro"))
       classpath(r8Configuration)
       main = "com.android.tools.r8.PrintUses"
 

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/InferAndroidTestKeepRules.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/InferAndroidTestKeepRules.kt
@@ -94,7 +94,7 @@ abstract class InferAndroidTestKeepRules : JavaExec() {
     operator fun invoke(
         variantName: String,
         androidTestJarProvider: TaskProvider<out Jar>,
-        releaseClassesJarProvider: TaskProvider<out Jar>,
+        releaseClassesJarProvider: TaskProvider<out VariantClasspathJar>,
         androidJar: Provider<RegularFile>,
         automaticallyAddR8Repo: Property<Boolean>,
         extensionJvmArgs: ListProperty<String>,

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperPlugin.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperPlugin.kt
@@ -226,11 +226,9 @@ class KeeperPlugin : Plugin<Project> {
    */
   private fun Project.createIntermediateAppJar(
       appVariant: BaseVariant
-  ): TaskProvider<out Jar> {
+  ): TaskProvider<out VariantClasspathJar> {
     return tasks.register<VariantClasspathJar>("jar${appVariant.name.capitalize(US)}ClassesForKeeper") {
       group = KEEPER_TASK_GROUP
-      val outputDir = project.layout.buildDirectory.dir(INTERMEDIATES_DIR)
-      archiveBaseName.set(appVariant.name)
       with(appVariant) {
         from(project.layout.dir(javaCompileProvider.map { it.destinationDir }))
         artifactFiles.from(runtimeConfiguration.artifactView().artifacts.artifactFiles)
@@ -239,16 +237,11 @@ class KeeperPlugin : Plugin<Project> {
         tasks.providerWithNameOrNull<KotlinCompile>(
             "compile${name.capitalize(US)}Kotlin")
             ?.let { kotlinCompileTask ->
-              from(project.layout.dir(kotlinCompileTask.map { it.destinationDir })) {
-                include("**/*.class")
-              }
+              from(project.layout.dir(kotlinCompileTask.map { it.destinationDir }))
             }
       }
 
-      destinationDirectory.set(outputDir)
-
-      // Because we have more than 65535 classes. Dex method limit's distant cousin.
-      isZip64 = true
+      archiveFile.set(project.layout.buildDirectory.dir(INTERMEDIATES_DIR).map { it.file("${appVariant.name}.jar") })
     }
   }
 }

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/VariantClasspathJar.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/VariantClasspathJar.kt
@@ -52,7 +52,7 @@ abstract class VariantClasspathJar @Inject constructor(objects: ObjectFactory) :
    * unused. See [configuration].
    */
   @get:Classpath
-  val artifactFiles = objects.fileCollection()
+  val artifactFiles: ConfigurableFileCollection = objects.fileCollection()
 
   /**
    * This is what the task actually uses as its input.
@@ -83,6 +83,7 @@ abstract class VariantClasspathJar @Inject constructor(objects: ObjectFactory) :
       classpath.asSequence()
           .flatMap { it.classesSequence() }
           .forEach { (name, file) ->
+            archive.delete(name)
             archive.add(BytesSource(file, name, Deflater.NO_COMPRESSION))
           }
     }
@@ -108,7 +109,7 @@ abstract class AndroidTestVariantClasspathJar @Inject constructor(
    * unused. See [appConfiguration].
    */
   @get:Classpath
-  val appArtifactFiles = objects.fileCollection()
+  val appArtifactFiles: ConfigurableFileCollection = objects.fileCollection()
 
   /**
    * This is what the task actually uses as its input.
@@ -121,7 +122,7 @@ abstract class AndroidTestVariantClasspathJar @Inject constructor(
    * unused. See [androidTestArtifactFiles].
    */
   @get:Classpath
-  val androidTestArtifactFiles = objects.fileCollection()
+  val androidTestArtifactFiles: ConfigurableFileCollection = objects.fileCollection()
 
   /** This is what the task actually uses as its input. */
   @get:Internal
@@ -180,6 +181,7 @@ abstract class AndroidTestVariantClasspathJar @Inject constructor(
       classpath.asSequence()
           .flatMap { it.classesSequence() }
           .forEach { (name, file) ->
+            archive.delete(name)
             archive.add(BytesSource(file, name, Deflater.NO_COMPRESSION))
           }
     }

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/VariantClasspathJar.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/VariantClasspathJar.kt
@@ -15,6 +15,7 @@
  */
 
 @file:Suppress("UnstableApiUsage")
+
 package com.slack.keeper
 
 import com.android.zipflinger.BytesSource
@@ -35,7 +36,6 @@ import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.property
 import java.util.zip.Deflater
 import javax.inject.Inject
-import kotlin.system.measureTimeMillis
 
 /**
  * A simple cacheable task that creates a jar from a given [classpath]. Normally these aren't
@@ -79,7 +79,7 @@ abstract class VariantClasspathJar @Inject constructor(objects: ObjectFactory) :
         archive.extractClassesFrom(it)
       }
 
-      // Take the compiled classpath
+      // Take the compiled classes
       classpath.asSequence()
           .flatMap { it.classesSequence() }
           .forEach { (name, file) ->
@@ -96,7 +96,8 @@ abstract class VariantClasspathJar @Inject constructor(objects: ObjectFactory) :
  * APIs that _they_ use that are used in the target app runtime, and we want R8 to account for those usages as well.
  */
 @CacheableTask
-abstract class AndroidTestVariantClasspathJar @Inject constructor(objects: ObjectFactory) : Jar() {
+abstract class AndroidTestVariantClasspathJar @Inject constructor(
+    objects: ObjectFactory) : DefaultTask() {
 
   private companion object {
     val LOG = AndroidTestVariantClasspathJar::class.simpleName!!
@@ -129,37 +130,59 @@ abstract class AndroidTestVariantClasspathJar @Inject constructor(objects: Objec
   @get:Input
   val emitDebugInfo: Property<Boolean> = objects.property()
 
-  override fun copy() {
-    measureTimeMillis {
-      project.logger.debug("$LOG: Diffing androidTest jars and app jars")
-      val appJars = appConfiguration.artifactView().files.filterTo(LinkedHashSet()) { it.extension == "jar" }
-      diagnostic("${archiveFile.get().asFile.nameWithoutExtension}AppJars") {
-        appJars.sortedBy { it.path }
-            .joinToString("\n") {
-              it.path
-            }
-      }
-      val androidTestClasspath = androidTestConfiguration.artifactView().files.filterTo(LinkedHashSet()) { it.extension == "jar" }
-      diagnostic("${archiveFile.get().asFile.nameWithoutExtension}Jars") {
-        androidTestClasspath.sortedBy { it.path }
-            .joinToString("\n") {
-              it.path
-            }
-      }
-      val distinctAndroidTestClasspath = androidTestClasspath.toMutableSet().apply {
-        removeAll(appJars)
-      }
-      diagnostic("${archiveFile.get().asFile.nameWithoutExtension}DistinctJars2") {
-        distinctAndroidTestClasspath.sortedBy { it.path }
-            .joinToString("\n") {
-              it.path
-            }
-      }
-      from(distinctAndroidTestClasspath.filter { it.extension == "jar" }.map(project::zipTree))
-    }.also {
-      project.logger.debug("$LOG: Diffing completed in ${it}ms")
+  @Suppress("UnstableApiUsage")
+  @get:Classpath
+  val classpath: ConfigurableFileCollection = objects.fileCollection()
+
+  @get:OutputFile
+  val archiveFile: RegularFileProperty = objects.fileProperty()
+
+  fun from(vararg paths: Any) {
+    classpath.from(*paths)
+  }
+
+  @TaskAction
+  fun createJar() {
+    project.logger.debug("$LOG: Diffing androidTest jars and app jars")
+    val appJars = appConfiguration.artifactView().files.filterTo(
+        LinkedHashSet()) { it.extension == "jar" }
+    diagnostic("${archiveFile.get().asFile.nameWithoutExtension}AppJars") {
+      appJars.sortedBy { it.path }
+          .joinToString("\n") {
+            it.path
+          }
     }
-    super.copy()
+    val androidTestClasspath = androidTestConfiguration.artifactView().files.filterTo(
+        LinkedHashSet()) { it.extension == "jar" }
+    diagnostic("${archiveFile.get().asFile.nameWithoutExtension}Jars") {
+      androidTestClasspath.sortedBy { it.path }
+          .joinToString("\n") {
+            it.path
+          }
+    }
+    val distinctAndroidTestClasspath = androidTestClasspath.toMutableSet().apply {
+      removeAll(appJars)
+    }
+    diagnostic("${archiveFile.get().asFile.nameWithoutExtension}DistinctJars2") {
+      distinctAndroidTestClasspath.sortedBy { it.path }
+          .joinToString("\n") {
+            it.path
+          }
+    }
+
+    ZipArchive(archiveFile.asFile.get()).use { archive ->
+      // The runtime classpath (i.e. from dependencies)
+      distinctAndroidTestClasspath.filter { it.extension == "jar" }.forEach {
+        archive.extractClassesFrom(it)
+      }
+
+      // Take the compiled classes
+      classpath.asSequence()
+          .flatMap { it.classesSequence() }
+          .forEach { (name, file) ->
+            archive.add(BytesSource(file, name, Deflater.NO_COMPRESSION))
+          }
+    }
   }
 
   private fun diagnostic(fileName: String, body: () -> String) {

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/VariantClasspathJar.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/VariantClasspathJar.kt
@@ -73,7 +73,6 @@ abstract class VariantClasspathJar @Inject constructor(objects: ObjectFactory) :
 
   @TaskAction
   fun createJar() {
-    from(configuration.artifactView().files.filter { it.extension == "jar" }.map(project::zipTree))
     ZipArchive(archiveFile.asFile.get()).use { archive ->
       // The runtime classpath (i.e. from dependencies)
       configuration.artifactView().files.filter { it.extension == "jar" }.forEach {

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/ZipFlingerExt.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/ZipFlingerExt.kt
@@ -25,7 +25,9 @@ internal fun ZipArchive.extractClassesFrom(jar: File) {
       .filterNot { "META-INF" in it.key }
       .forEach { (name, entry) ->
         if (!entry.isDirectory && entry.name.endsWith(".class")) {
-          jarSource.select(name.removePrefix("."), name)
+          val entryName = name.removePrefix(".")
+          delete(entryName)
+          jarSource.select(entryName, name)
         }
       }
   add(jarSource)

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/ZipFlingerExt.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/ZipFlingerExt.kt
@@ -1,0 +1,29 @@
+package com.slack.keeper
+
+import com.android.zipflinger.ZipArchive
+import com.android.zipflinger.ZipSource
+import java.io.File
+
+/**
+ * Returns a sequence of pairs representing the class files and their relative names for use in a
+ * zip entry.
+ */
+internal fun File.classesSequence(): Sequence<Pair<String, File>> {
+  val prefix = absolutePath
+  return walkTopDown()
+      .filter { it.extension == "class" }
+      .map { it.absolutePath.removePrefix(prefix).removePrefix("/") to it }
+}
+
+/**
+ * Extracts classes from the target [jar] into this archive.
+ */
+internal fun ZipArchive.extractClassesFrom(jar: File) {
+  val jarSource = ZipSource(jar)
+  jarSource.entries().forEach { (name, entry) ->
+    if (!entry.isDirectory && entry.name.endsWith(".class")) {
+      jarSource.select(name.removePrefix("."), name)
+    }
+  }
+  add(jarSource)
+}

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/ZipFlingerExt.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/ZipFlingerExt.kt
@@ -12,6 +12,7 @@ internal fun File.classesSequence(): Sequence<Pair<String, File>> {
   val prefix = absolutePath
   return walkTopDown()
       .filter { it.extension == "class" }
+      .filterNot { "META-INF" in it.name }
       .map { it.absolutePath.removePrefix(prefix).removePrefix("/") to it }
 }
 
@@ -20,10 +21,12 @@ internal fun File.classesSequence(): Sequence<Pair<String, File>> {
  */
 internal fun ZipArchive.extractClassesFrom(jar: File) {
   val jarSource = ZipSource(jar)
-  jarSource.entries().forEach { (name, entry) ->
-    if (!entry.isDirectory && entry.name.endsWith(".class")) {
-      jarSource.select(name.removePrefix("."), name)
-    }
-  }
+  jarSource.entries()
+      .filterNot { "META-INF" in it.key }
+      .forEach { (name, entry) ->
+        if (!entry.isDirectory && entry.name.endsWith(".class")) {
+          jarSource.select(name.removePrefix("."), name)
+        }
+      }
   add(jarSource)
 }

--- a/publish.sh
+++ b/publish.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 
 if [[ "$1" = "--snapshot" ]]; then snapshot=true; fi
+if [[ "$1" = "--local" ]]; then local=true; fi
 
 cd keeper-gradle-plugin
-./gradlew clean uploadArchives --no-daemon --no-parallel -Pkeeper.releaseMode=true
-
-if ! [[ ${snapshot} ]]; then
-  ./gradlew closeAndReleaseRepository
+if ! [[ ${local} ]]; then
+  ./gradlew clean uploadArchives --no-daemon --no-parallel -Pkeeper.releaseMode=true
+  if ! [[ ${snapshot} ]]; then
+    ./gradlew closeAndReleaseRepository
+  fi
+else
+  ./gradlew clean install --no-daemon --no-parallel -Pkeeper.releaseMode=true
 fi
+
 cd ..


### PR DESCRIPTION
Resolves #20 

Perf comparisons on the slack app:

| Task | Before | After |
|-|--------|-------|
| inferExternalStagingAndroidTestKeepRulesForKeeper | 14.126s | 11.138s |
| jarExternalStagingClassesForKeeper | 10.364s | 6.347s |
| jarExternalStagingAndroidTestClassesForKeeper | 4.504s | 2.609s |

~~Will do some perf comparisons in our app and report the findings here~~

~~**On hold as ZipFlinger fails explosively when there are colliding names:** https://issuetracker.google.com/issues/150320652~~