### PR TITLE
Update maven publish plugin to 0.11.1

### DIFF
--- a/keeper-gradle-plugin/build.gradle.kts
+++ b/keeper-gradle-plugin/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     `java-gradle-plugin`
     kotlin("jvm") version "1.3.71"
     kotlin("kapt") version "1.3.71"
-    id("com.vanniktech.maven.publish") version "0.10.0"
+    id("com.vanniktech.maven.publish") version "0.11.1"
 }
 
 buildscript {


### PR DESCRIPTION
This has a fix for gradle plugin uploads that was used for our 0.3.1 upload