### PR TITLE
Log test methods for faster feedback.

### DIFF
--- a/keeper-gradle-plugin/build.gradle.kts
+++ b/keeper-gradle-plugin/build.gradle.kts
@@ -46,6 +46,12 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach 
   }
 }
 
+tasks.withType<Test>().configureEach {
+  beforeTest(closureOf<TestDescriptor> {
+    logger.lifecycle("Running test: $this")
+  })
+}
+
 sourceSets {
   getByName("test").resources.srcDirs("$buildDir/pluginUnderTestMetadata")
 }


### PR DESCRIPTION
The first time I ran the `test` task against the plugin, it seemed like it was hanging and I ctrl-c'd. Eventually I figured out they were just very slow tests (the functional tests). I use this approach in [my own project](https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin) so I can keep tabs on progress.

Output looks like:
```
> Task :test
Running test: Test variantFilter[R8](com.slack.keeper.KeeperFunctionalTest)
Running test: Test variantFilterWarning[R8](com.slack.keeper.KeeperFunctionalTest)
Running test: Test standard[R8](com.slack.keeper.KeeperFunctionalTest)
Running test: Test manualR8RepoManagement[R8](com.slack.keeper.KeeperFunctionalTest)
Running test: Test variantFilter[PROGUARD](com.slack.keeper.KeeperFunctionalTest)
Running test: Test variantFilterWarning[PROGUARD](com.slack.keeper.KeeperFunctionalTest)
Running test: Test standard[PROGUARD](com.slack.keeper.KeeperFunctionalTest)
Running test: Test manualR8RepoManagement[PROGUARD](com.slack.keeper.KeeperFunctionalTest)
```