### PR TITLE
Support AGP 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         ci_java_version: [1.8]
-        ci_agp_version: [3.6.3, 4.0.0, 4.1.0-alpha10]
+        ci_agp_version: [3.6.3, 4.0.0]
         job: [instrumentation, plugin]
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         ci_java_version: [1.8]
-        ci_agp_version: [3.6.3]
+        ci_agp_version: [3.6.3, 4.0.0, 4.1.0-alpha10]
         job: [instrumentation, plugin]
     steps:
       - name: Checkout
@@ -66,11 +66,11 @@ jobs:
           path: build-reports.zip
       - name: Reclaim memory
         run: ./gradlew --stop && jps|grep -E 'KotlinCompileDaemon|GradleDaemon'| awk '{print $1}'| xargs kill -9 || true
-        if: success() && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && matrix.ci_java_version == '1.8' && matrix.ci_agp_version == '3.6.1' && matrix.job == 'plugin'
+        if: success() && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && matrix.ci_java_version == '1.8' && matrix.ci_agp_version == '3.6.3' && matrix.job == 'plugin'
       - name: Upload snapshot (master only)
         env:
           ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SonatypeUsername }}
           ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: ${{ secrets.SonatypePassword }}
         run: |
           ./publish.sh --snapshot
-        if: success() && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && matrix.ci_java_version == '1.8' && matrix.ci_agp_version == '3.6.1' && matrix.job == 'plugin'
+        if: success() && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && matrix.ci_java_version == '1.8' && matrix.ci_agp_version == '3.6.3' && matrix.job == 'plugin'

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         jcenter()
     }
 
-    String defaultAgpVersion = "3.6.1"
+    String defaultAgpVersion = "3.6.3"
     String agpVersion = findProperty("keeperTest.agpVersion")?.toString() ?: defaultAgpVersion
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-rc-1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/keeper-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/keeper-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-rc-1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/InferAndroidTestKeepRules.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/InferAndroidTestKeepRules.kt
@@ -63,6 +63,13 @@ abstract class InferAndroidTestKeepRules : JavaExec() {
   @get:Input
   abstract val jvmArgsProperty: ListProperty<String>
 
+  /**
+   * Enable more descriptive precondition checks in the CLI. If disabled, errors will be emitted to
+   * the generated proguard rules file instead.
+   */
+  @get:Input
+  abstract val enableAssertionsProperty: Property<Boolean>
+
   @get:OutputFile
   abstract val outputProguardRules: RegularFileProperty
 
@@ -79,6 +86,7 @@ abstract class InferAndroidTestKeepRules : JavaExec() {
       }
     }
 
+    enableAssertions = enableAssertionsProperty.get()
     standardOutput = outputProguardRules.asFile.get().outputStream().buffered()
     args = listOf(
         "--keeprules",
@@ -99,6 +107,7 @@ abstract class InferAndroidTestKeepRules : JavaExec() {
         releaseClassesJarProvider: TaskProvider<out VariantClasspathJar>,
         androidJar: Provider<RegularFile>,
         automaticallyAddR8Repo: Property<Boolean>,
+        enableAssertions: Property<Boolean>,
         extensionJvmArgs: ListProperty<String>,
         r8Configuration: Configuration
     ): InferAndroidTestKeepRules.() -> Unit = {
@@ -131,8 +140,7 @@ abstract class InferAndroidTestKeepRules : JavaExec() {
       classpath(r8Configuration)
       main = "com.android.tools.r8.PrintUses"
 
-      // Enable more descriptive precondition checks in the CLI
-      enableAssertions = true
+      enableAssertionsProperty.set(enableAssertions)
     }
   }
 }

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperExtension.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperExtension.kt
@@ -59,6 +59,10 @@ open class KeeperExtension @Inject constructor(objects: ObjectFactory) {
   /** Emit extra debug information, useful for bug reporting. */
   @Suppress("UnstableApiUsage")
   var emitDebugInformation: Property<Boolean> = objects.property<Boolean>().convention(false)
+
+  /** Controls whether or not to enable assertions in the JavaExec run of R8. Default is true. */
+  @Suppress("UnstableApiUsage")
+  var enableAssertions: Property<Boolean> = objects.property<Boolean>().convention(true)
 }
 
 

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperPlugin.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperPlugin.kt
@@ -167,6 +167,7 @@ class KeeperPlugin : Plugin<Project> {
                   releaseClassesJarProvider = intermediateAppJar,
                   androidJar = androidJarRegularFileProvider,
                   automaticallyAddR8Repo = extension.automaticR8RepoManagement,
+                  enableAssertions = extension.enableAssertions,
                   extensionJvmArgs = extension.r8JvmArgs,
                   r8Configuration = r8Configuration
               )

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperPlugin.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperPlugin.kt
@@ -21,6 +21,7 @@ package com.slack.keeper
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.api.BaseVariant
 import com.android.build.gradle.api.TestVariant
+import com.android.build.gradle.internal.publishing.AndroidArtifacts
 import com.android.builder.model.BuildType
 import com.android.builder.model.ProductFlavor
 import org.gradle.api.Plugin
@@ -29,7 +30,6 @@ import org.gradle.api.Task
 import org.gradle.api.UnknownTaskException
 import org.gradle.api.artifacts.ArtifactView
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.attributes.Attribute
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
@@ -96,6 +96,8 @@ class KeeperPlugin : Plugin<Project> {
     with(project) {
       pluginManager.withPlugin("com.android.application") {
         val extension = project.extensions.create<KeeperExtension>("keeper")
+        val agpHandler = AgpVersionHandler.getInstance()
+            .also { logger.debug("$TAG Using ${it.minVersion} patcher") }
 
         // Set up r8 configuration
         val r8Configuration = configurations.create(CONFIGURATION_NAME) {
@@ -151,11 +153,12 @@ class KeeperPlugin : Plugin<Project> {
           }
 
           val intermediateAndroidTestJar = createIntermediateAndroidTestJar(
+              agpHandler,
               extension.emitDebugInformation,
               this,
               appVariant
           )
-          val intermediateAppJar = createIntermediateAppJar(appVariant)
+          val intermediateAppJar = createIntermediateAppJar(agpHandler, appVariant)
           val inferAndroidTestUsageProvider = tasks.register(
               "infer${name.capitalize(US)}KeepRulesForKeeper",
               InferAndroidTestKeepRules(
@@ -171,9 +174,7 @@ class KeeperPlugin : Plugin<Project> {
 
           val prop = project.layout.dir(
               inferAndroidTestUsageProvider.flatMap { it.outputProguardRules.asFile })
-          AgpVersionHandler.getInstance()
-              .also { logger.debug("$TAG Using ${it.minVersion} patcher") }
-              .applyGeneratedRules(project, appVariant.name, prop)
+          agpHandler.applyGeneratedRules(project, appVariant.name, prop)
         }
       }
     }
@@ -184,6 +185,7 @@ class KeeperPlugin : Plugin<Project> {
    * This output is used in the inferAndroidTestUsage task.
    */
   private fun Project.createIntermediateAndroidTestJar(
+      agpHandler: AgpVersionHandler,
       emitDebugInfo: Property<Boolean>,
       testVariant: TestVariant,
       appVariant: BaseVariant
@@ -194,14 +196,14 @@ class KeeperPlugin : Plugin<Project> {
       this.emitDebugInfo.value(emitDebugInfo)
 
       with(appVariant) {
-        appArtifactFiles.from(runtimeConfiguration.artifactView().artifacts.artifactFiles)
-        appConfiguration = runtimeConfiguration
+        appArtifactFiles.from(compileConfiguration.artifactView(agpHandler).artifacts.artifactFiles)
+        appConfiguration.set(runtimeConfiguration)
       }
 
       with(testVariant) {
         from(project.layout.dir(javaCompileProvider.map { it.destinationDir }))
-        androidTestArtifactFiles.from(runtimeConfiguration.artifactView().artifacts.artifactFiles)
-        androidTestConfiguration = runtimeConfiguration
+        androidTestArtifactFiles.from(compileConfiguration.artifactView(agpHandler).artifacts.artifactFiles)
+        androidTestConfiguration.set(runtimeConfiguration)
         tasks.providerWithNameOrNull<KotlinCompile>(
             "compile${name.capitalize(US)}Kotlin")
             ?.let { kotlinCompileTask ->
@@ -220,6 +222,7 @@ class KeeperPlugin : Plugin<Project> {
    * output is used in the inferAndroidTestUsage task.
    */
   private fun Project.createIntermediateAppJar(
+      agpHandler: AgpVersionHandler,
       appVariant: BaseVariant
   ): TaskProvider<out VariantClasspathJar> {
     return tasks.register<VariantClasspathJar>(
@@ -227,8 +230,8 @@ class KeeperPlugin : Plugin<Project> {
       group = KEEPER_TASK_GROUP
       with(appVariant) {
         from(project.layout.dir(javaCompileProvider.map { it.destinationDir }))
-        artifactFiles.from(runtimeConfiguration.artifactView().artifacts.artifactFiles)
-        configuration = runtimeConfiguration
+        artifactFiles.from(compileConfiguration.artifactView(agpHandler).artifacts.artifactFiles)
+        configuration.set(runtimeConfiguration)
 
         tasks.providerWithNameOrNull<KotlinCompile>(
             "compile${name.capitalize(US)}Kotlin")
@@ -244,16 +247,17 @@ class KeeperPlugin : Plugin<Project> {
   }
 }
 
-internal fun Configuration.artifactView(): ArtifactView {
+internal fun Configuration.artifactView(agpHandler: AgpVersionHandler): ArtifactView {
   return incoming.artifactView {
     attributes {
-      attribute(Attribute.of("artifactType", String::class.java), "android-classes")
+      attribute(AndroidArtifacts.ARTIFACT_TYPE, agpHandler.artifactTypeValue)
     }
   }
 }
 
 private inline fun <reified T : Task> TaskContainer.providerWithNameOrNull(
-    name: String): TaskProvider<T>? {
+    name: String
+): TaskProvider<T>? {
   return try {
     named<T>(name)
   } catch (e: UnknownTaskException) {

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperPlugin.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperPlugin.kt
@@ -197,13 +197,13 @@ class KeeperPlugin : Plugin<Project> {
       this.emitDebugInfo.value(emitDebugInfo)
 
       with(appVariant) {
-        appArtifactFiles.from(compileConfiguration.artifactView(agpHandler).artifacts.artifactFiles)
+        appArtifactFiles.from(runtimeConfiguration.artifactView(agpHandler).artifacts.artifactFiles)
         appConfiguration.set(runtimeConfiguration)
       }
 
       with(testVariant) {
         from(project.layout.dir(javaCompileProvider.map { it.destinationDir }))
-        androidTestArtifactFiles.from(compileConfiguration.artifactView(agpHandler).artifacts.artifactFiles)
+        androidTestArtifactFiles.from(runtimeConfiguration.artifactView(agpHandler).artifacts.artifactFiles)
         androidTestConfiguration.set(runtimeConfiguration)
         tasks.providerWithNameOrNull<KotlinCompile>(
             "compile${name.capitalize(US)}Kotlin")
@@ -231,7 +231,7 @@ class KeeperPlugin : Plugin<Project> {
       group = KEEPER_TASK_GROUP
       with(appVariant) {
         from(project.layout.dir(javaCompileProvider.map { it.destinationDir }))
-        artifactFiles.from(compileConfiguration.artifactView(agpHandler).artifacts.artifactFiles)
+        artifactFiles.from(runtimeConfiguration.artifactView(agpHandler).artifacts.artifactFiles)
         configuration.set(runtimeConfiguration)
 
         tasks.providerWithNameOrNull<KotlinCompile>(

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -108,10 +108,10 @@ dependencies {
   androidTestImplementation project(":sample-libraries:c")
   androidTestImplementation "com.squareup.okio:okio:2.6.0"
   androidTestImplementation "androidx.annotation:annotation:1.1.0"
-  androidTestImplementation "androidx.test:rules:1.3.0-beta01"
-  androidTestImplementation "androidx.test:runner:1.3.0-beta01"
-  androidTestImplementation "androidx.test:orchestrator:1.3.0-beta01"
-  androidTestImplementation "androidx.test.ext:junit:1.1.2-beta01"
+  androidTestImplementation "androidx.test:rules:1.3.0-rc01"
+  androidTestImplementation "androidx.test:runner:1.3.0-rc01"
+  androidTestImplementation "androidx.test:orchestrator:1.3.0-rc01"
+  androidTestImplementation "androidx.test.ext:junit:1.1.2-rc01"
   androidTestImplementation "junit:junit:4.13"
   androidTestImplementation "com.google.truth:truth:1.0.1"
 }


### PR DESCRIPTION
AGP 4 uses a different `android-classes-jar` attribute value for artifact viewing

Resolves #45 