### PR TITLE
More diagnostic info + only process app artifacts once

### DIFF
--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperPlugin.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperPlugin.kt
@@ -127,7 +127,7 @@ class KeeperPlugin : Plugin<Project> {
           }
         }
         val androidJarRegularFileProvider = project.layout.file(androidJarFileProvider)
-        val diagnosticOutputDir = layout.buildDirectory.dir(INTERMEDIATES_DIR)
+        val diagnosticOutputDir = layout.buildDirectory.dir("$INTERMEDIATES_DIR/diagnostics")
 
         appExtension.testVariants.configureEach {
           val appVariant = testedVariant

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/ZipFlingerExt.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/ZipFlingerExt.kt
@@ -19,13 +19,14 @@ internal fun File.classesSequence(): Sequence<Pair<String, File>> {
 /**
  * Extracts classes from the target [jar] into this archive.
  */
-internal fun ZipArchive.extractClassesFrom(jar: File) {
+internal fun ZipArchive.extractClassesFrom(jar: File, callback: (String) -> Unit) {
   val jarSource = ZipSource(jar)
   jarSource.entries()
       .filterNot { "META-INF" in it.key }
       .forEach { (name, entry) ->
         if (!entry.isDirectory && entry.name.endsWith(".class")) {
           val entryName = name.removePrefix(".")
+          callback(entryName)
           delete(entryName)
           jarSource.select(entryName, name)
         }


### PR DESCRIPTION
Nice little optimization by reusing the previous task's output. This, I think, allows changing the app classpath in a compatible way without making the test jar  bundling out of date