### PR TITLE
Make the default behavior to ignore minifyEnabled = false variants

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,7 +71,7 @@ if (!hasProperty("productionBuild")) {
 
 ### Variant filter
 
-By default, Keeper will run on any app variant that sets minifyEnabled = true.
+By default, Keeper will run on any app variant that sets `minifyEnabled` to true.
 
 Alternatively, you can specify a `variantFilter` on the `keeper` extension and dynamically configure
 which variants Keeper operates on. This is nearly identical to AGP's native `variantFilter` API except

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,9 +71,11 @@ if (!hasProperty("productionBuild")) {
 
 ### Variant filter
 
-You can specify a `variantFilter` on the `keeper` extension and dynamically configure which variants
-Keeper operates on. This is nearly identical to AGP's native `variantFilter` API except that there
-is no `defaultConfig` property.
+By default, Keeper will run on any app variant that sets minifyEnabled = true.
+
+Alternatively, you can specify a `variantFilter` on the `keeper` extension and dynamically configure
+which variants Keeper operates on. This is nearly identical to AGP's native `variantFilter` API except
+that there is no `defaultConfig` property.
 
 **Note:** Variants with different `enabled` values will have to be compiled separately. This is common
 in most multi-variant projects anyway, but something to be aware of.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
-Keeper's default behavior with no configuration will enable it for _all_
-androidTest variants. This may not be what you want for your actual production builds that you plan
-to distribute.
+Keeper's default behavior with no configuration will enable it for only buildTypes which use
+minifyEnabled = true. This may not be what you want for your actual production builds that you
+plan to distribute.
 
 Normally, your app variant's minification task doesn't depend on compilation of its corresponding
 `androidTest` variant. This means you can call `assembleRelease` and `assembleAndroidTestRelease`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,5 @@
-Keeper's default behavior with no configuration will enable it for only buildTypes which use
-minifyEnabled = true. This may not be what you want for your actual production builds that you
+Keeper's default behavior with no configuration will enable it for only buildTypes that set
+`minifyEnabled` to true. This may not be what you want for your actual production builds that you
 plan to distribute.
 
 Normally, your app variant's minification task doesn't depend on compilation of its corresponding

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperPlugin.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperPlugin.kt
@@ -139,7 +139,7 @@ class KeeperPlugin : Plugin<Project> {
             it.execute(filter)
             project.logger.debug("$TAG Variant '${appVariant.name}' ignored? ${filter._ignored}")
             filter._ignored
-          } ?: false
+          } ?: !appVariant.buildType.isMinifyEnabled
           if (ignoredVariant) {
             return@configureEach
           }

--- a/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperPlugin.kt
+++ b/keeper-gradle-plugin/src/main/kotlin/com/slack/keeper/KeeperPlugin.kt
@@ -322,7 +322,7 @@ internal fun String.capitalize(locale: Locale): String {
 
 private class VariantFilterImpl(variant: BaseVariant) : VariantFilter {
   @Suppress("PropertyName")
-  var _ignored: Boolean = true
+  var _ignored: Boolean = false
 
   override fun setIgnore(ignore: Boolean) {
     _ignored = ignore

--- a/keeper-gradle-plugin/src/test/kotlin/com/slack/keeper/KeeperFunctionalTest.kt
+++ b/keeper-gradle-plugin/src/test/kotlin/com/slack/keeper/KeeperFunctionalTest.kt
@@ -165,7 +165,6 @@ class KeeperFunctionalTest(private val minifierType: MinifierType) {
     assertThat(result.findTask("jarInternalDebugAndroidTestClassesForKeeper")).isNull()
     assertThat(result.findTask("jarInternalDebugClassesForKeeper")).isNull()
     assertThat(result.findTask("inferInternalDebugAndroidTestKeepRulesForKeeper")).isNull()
-    assertThat(result.output).contains("Keeper is configured to generate keep rules for the \"internalDebug\" build variant")
   }
 
   // Ensures that manual R8 repo management works


### PR DESCRIPTION
As reported in #60, the behavior of the variantFilter does not match the documentation.

This PR sets a better default by disabling Keeper for all variants where minifyEnabled = false.

It also uses ignored = false as the default when a user does specify a variantFilter which says nothing about the current variant. This matches the current documentation.

I hope you can agree that this behavior is preferable.