### PR TITLE
Re-work variantFilter in functional tests to cover more cases

### DIFF
--- a/keeper-gradle-plugin/src/test/kotlin/com/slack/keeper/KeeperFunctionalTest.kt
+++ b/keeper-gradle-plugin/src/test/kotlin/com/slack/keeper/KeeperFunctionalTest.kt
@@ -101,7 +101,7 @@ class KeeperFunctionalTest(private val minifierType: MinifierType) {
 
   @Rule
   @JvmField
-  val temporaryFolder = TemporaryFolder()
+  val temporaryFolder: TemporaryFolder = TemporaryFolder.builder().assureDeletion().build()
 
   /**
    * Basic smoke test. This covers the standard flow and touches on the following:
@@ -141,23 +141,32 @@ class KeeperFunctionalTest(private val minifierType: MinifierType) {
     assertThat(proguardConfigOutput.readText().trim()).contains(minifierType.expectedRules)
   }
 
-  // Asserts that our variant filter properly filters things out. In our fixture project, this is
-  // the externalRelease variant
+  // Asserts that our variant filter properly filters things out. In our fixture project, the
+  // "externalRelease" build variant will be ignored, while tasks will be generated for the
+  // "internalRelease" variant.
   @Test
   fun variantFilter() {
-    val (projectDir, _) = prepareProject(temporaryFolder, buildGradleFile("release"))
+    val (projectDir, _) = prepareProject(temporaryFolder, buildGradleFile("release",
+        sampleVariantFilter = SampleVariantFilter.ONLY_INTERNAL_RELEASE))
 
-    val result = runGradle(projectDir, "assembleExternalRelease", "-x", "lintVitalExternalRelease")
+    val result = runGradle(projectDir, "assembleExternalRelease", "assembleInternalRelease", "-x",
+        "lintVitalExternalRelease", "-x", "lintVitalInternalRelease")
     assertThat(result.findTask("jarExternalReleaseAndroidTestClassesForKeeper")).isNull()
     assertThat(result.findTask("jarExternalReleaseClassesForKeeper")).isNull()
-    assertThat(result.findTask("inferExternalStagingAndroidTestKeepRulesForKeeper")).isNull()
+    assertThat(result.findTask("inferExternalReleaseAndroidTestKeepRulesForKeeper")).isNull()
+
+    assertThat(result.resultOf("jarInternalReleaseAndroidTestClassesForKeeper")).isEqualTo(TaskOutcome.SUCCESS)
+    assertThat(result.resultOf("jarInternalReleaseClassesForKeeper")).isEqualTo(TaskOutcome.SUCCESS)
+    assertThat(result.resultOf("inferInternalReleaseAndroidTestKeepRulesForKeeper")).isEqualTo(TaskOutcome.SUCCESS)
   }
 
   // Asserts that if Keeper was configured to create keep rules for a variant that isn't minified,
   // an error will be emitted, and the tasks won't be created.
   @Test
   fun variantFilterWarning() {
-    val (projectDir, _) = prepareProject(temporaryFolder, buildGradleFile("debug", includeVariantFilter = false))
+    // internalDebug variant isn't minified, but the variantFilter includes it.
+    val (projectDir, _) = prepareProject(temporaryFolder, buildGradleFile("debug",
+        sampleVariantFilter = SampleVariantFilter.ONLY_INTERNAL_DEBUG))
 
     val result = runGradle(projectDir, "assembleInternalDebug")
 
@@ -165,6 +174,7 @@ class KeeperFunctionalTest(private val minifierType: MinifierType) {
     assertThat(result.findTask("jarInternalDebugAndroidTestClassesForKeeper")).isNull()
     assertThat(result.findTask("jarInternalDebugClassesForKeeper")).isNull()
     assertThat(result.findTask("inferInternalDebugAndroidTestKeepRulesForKeeper")).isNull()
+    assertThat(result.output).contains("Keeper is configured to generate keep rules for the \"internalDebug\" build variant")
   }
 
   // Ensures that manual R8 repo management works
@@ -273,11 +283,29 @@ private val TEST_PROGUARD_RULES = """
   -dontnote **
 """.trimIndent()
 
+enum class SampleVariantFilter(val groovy: String) {
+  NONE(""),
+  ONLY_INTERNAL_RELEASE(
+      """
+      variantFilter {
+        setIgnore(name != "internalRelease")
+      }
+      """.trimIndent()
+  ),
+  ONLY_INTERNAL_DEBUG(
+      """
+      variantFilter {
+        setIgnore(name != "internalDebug")
+      }
+      """.trimIndent()
+  );
+}
+
 @Language("groovy")
 private fun buildGradleFile(
     testBuildType: String,
     automaticR8RepoManagement: Boolean = true,
-    includeVariantFilter: Boolean = true,
+    sampleVariantFilter: SampleVariantFilter = SampleVariantFilter.NONE,
     emitDebugInformation: Boolean = false,
     extraDependencies: Map<String, String> = emptyMap()
 ) = """
@@ -357,12 +385,8 @@ private fun buildGradleFile(
   
   keeper {
     ${if (automaticR8RepoManagement) "" else "automaticR8RepoManagement = false"}
-    ${if (!includeVariantFilter) "" else """
     emitDebugInformation.set($emitDebugInformation)
-    variantFilter {
-      setIgnore(name == "externalRelease")
-    }
-    """}
+    ${sampleVariantFilter.groovy}
   }
   
   dependencies {


### PR DESCRIPTION
#61 changed how we configure which variants keeper runs on, adding better defaults. This PR updates the functional tests to handle a few more cases, and adds back in a test case that checks the presence of the warning logged when keeper is configured to run for a non-minified build variant (using `setIgnore(false)` in a `variantFilter`).