### PR TITLE
Add support for the new TraceReferences entry-point

### DIFF
--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/InferAndroidTestKeepRules.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/InferAndroidTestKeepRules.kt
@@ -128,7 +128,9 @@ public abstract class InferAndroidTestKeepRules : JavaExec() {
       "--source" to androidTestSourceJar.get().asFile.absolutePath,
       "--output" to outputProguardRules.get().asFile.absolutePath
     ).map { if (it.second != null) listOf(it.first, it.second) else listOf() }
-      .reduce { acc, any -> acc + any } + traceReferencesArgs.getOrElse(listOf())
+      .reduce { acc, any -> acc + any }
+      // Add user provided args coming from TraceReferences.arguments after generated ones.
+      .plus(traceReferencesArgs.getOrElse(listOf()))
 
   public companion object {
     @Suppress("UNCHECKED_CAST", "UnstableApiUsage")

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/InferAndroidTestKeepRules.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/InferAndroidTestKeepRules.kt
@@ -26,6 +26,7 @@ import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.maven
@@ -53,10 +54,11 @@ public abstract class InferAndroidTestKeepRules : JavaExec() {
   public abstract val appTargetJar: RegularFileProperty
 
   @get:Classpath
-  public abstract val androidLib: RegularFileProperty
+  public abstract val androidJar: RegularFileProperty
 
   @get:Classpath
-  public abstract val androidTestLib: RegularFileProperty
+  @get:Optional
+  public abstract val androidTestJar: RegularFileProperty
 
   /**
    * Optional custom jvm arguments to pass into the exec. Useful if you want to enable debugging in R8.
@@ -101,7 +103,7 @@ public abstract class InferAndroidTestKeepRules : JavaExec() {
     args = when (traceReferencesEnabled.get()) {
       false -> listOf(
           "--keeprules",
-          androidLib.get().asFile.absolutePath,
+          androidJar.get().asFile.absolutePath,
           appTargetJar.get().asFile.absolutePath,
           androidTestSourceJar.get().asFile.absolutePath
       ).also {
@@ -110,8 +112,8 @@ public abstract class InferAndroidTestKeepRules : JavaExec() {
       }
       true -> listOf<Pair<String, String?>>(
           "--keep-rules" to "",
-          "--lib" to androidLib.get().asFile.absolutePath,
-          "--lib" to androidTestLib.orNull?.asFile?.absolutePath,
+          "--lib" to androidJar.get().asFile.absolutePath,
+          "--lib" to androidTestJar.orNull?.asFile?.absolutePath,
           "--target" to appTargetJar.get().asFile.absolutePath,
           "--source" to androidTestSourceJar.get().asFile.absolutePath,
           "--output" to outputProguardRules.get().asFile.absolutePath
@@ -156,8 +158,8 @@ public abstract class InferAndroidTestKeepRules : JavaExec() {
       group = KEEPER_TASK_GROUP
       androidTestSourceJar.set(androidTestJarProvider.flatMap { it.archiveFile })
       appTargetJar.set(releaseClassesJarProvider.flatMap { it.archiveFile })
-      androidLib.set(androidJar)
-      androidTestLib.set(androidTestJar)
+      this.androidJar.set(androidJar)
+      this.androidTestJar.set(androidTestJar)
       jvmArgsProperty.set(extensionJvmArgs)
       this.traceReferencesEnabled.set(traceReferencesEnabled)
       this.traceReferencesArgs.set(traceReferencesArgs)

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/InferAndroidTestKeepRules.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/InferAndroidTestKeepRules.kt
@@ -120,7 +120,7 @@ public abstract class InferAndroidTestKeepRules : JavaExec() {
     }
 
   private fun genTraceReferencesArgs(): List<String?> =
-    listOf<Pair<String, String?>>(
+    listOf(
       "--keep-rules" to "",
       "--lib" to androidJar.get().asFile.absolutePath,
       "--lib" to androidTestJar.orNull?.asFile?.absolutePath,

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/InferAndroidTestKeepRules.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/InferAndroidTestKeepRules.kt
@@ -101,28 +101,34 @@ public abstract class InferAndroidTestKeepRules : JavaExec() {
 
     enableAssertions = enableAssertionsProperty.get()
     args = when (traceReferencesEnabled.get()) {
-      false -> listOf(
-          "--keeprules",
-          androidJar.get().asFile.absolutePath,
-          appTargetJar.get().asFile.absolutePath,
-          androidTestSourceJar.get().asFile.absolutePath
-      ).also {
-        // print-uses is using its output to print rules
-        standardOutput = outputProguardRules.asFile.get().outputStream().buffered()
-      }
-      true -> listOf<Pair<String, String?>>(
-          "--keep-rules" to "",
-          "--lib" to androidJar.get().asFile.absolutePath,
-          "--lib" to androidTestJar.orNull?.asFile?.absolutePath,
-          "--target" to appTargetJar.get().asFile.absolutePath,
-          "--source" to androidTestSourceJar.get().asFile.absolutePath,
-          "--output" to outputProguardRules.get().asFile.absolutePath
-      ).map { if (it.second != null) listOf(it.first, it.second) else listOf() }
-          .reduce { acc, any -> acc + any } + traceReferencesArgs.getOrElse(listOf())
+      false -> genPrintUsesArgs()
+      true -> genTraceReferencesArgs()
     }
 
     super.exec()
   }
+
+  private fun genPrintUsesArgs(): List<String> =
+    listOf(
+      "--keeprules",
+      androidJar.get().asFile.absolutePath,
+      appTargetJar.get().asFile.absolutePath,
+      androidTestSourceJar.get().asFile.absolutePath
+    ).also {
+      // print-uses is using its output to print rules
+      standardOutput = outputProguardRules.asFile.get().outputStream().buffered()
+    }
+
+  private fun genTraceReferencesArgs(): List<String?> =
+    listOf<Pair<String, String?>>(
+      "--keep-rules" to "",
+      "--lib" to androidJar.get().asFile.absolutePath,
+      "--lib" to androidTestJar.orNull?.asFile?.absolutePath,
+      "--target" to appTargetJar.get().asFile.absolutePath,
+      "--source" to androidTestSourceJar.get().asFile.absolutePath,
+      "--output" to outputProguardRules.get().asFile.absolutePath
+    ).map { if (it.second != null) listOf(it.first, it.second) else listOf() }
+      .reduce { acc, any -> acc + any } + traceReferencesArgs.getOrElse(listOf())
 
   public companion object {
     @Suppress("UNCHECKED_CAST", "UnstableApiUsage")

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/InferAndroidTestKeepRules.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/InferAndroidTestKeepRules.kt
@@ -123,7 +123,7 @@ public abstract class InferAndroidTestKeepRules : JavaExec() {
     listOf(
       "--keep-rules" to "",
       "--lib" to androidJar.get().asFile.absolutePath,
-      "--lib" to androidTestJar.orNull?.asFile?.absolutePath,
+      "--lib" to androidTestJar.get().asFile.takeIf { it.exists() }?.absolutePath,
       "--target" to appTargetJar.get().asFile.absolutePath,
       "--source" to androidTestSourceJar.get().asFile.absolutePath,
       "--output" to outputProguardRules.get().asFile.absolutePath

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/InferAndroidTestKeepRules.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/InferAndroidTestKeepRules.kt
@@ -98,16 +98,16 @@ public abstract class InferAndroidTestKeepRules : JavaExec() {
     }
 
     enableAssertions = enableAssertionsProperty.get()
-    args = listOf(
-        "--keep-rules",
-        "--lib", androidLib.get().asFile.absolutePath,
-        "--lib", androidTestLib.get().asFile.absolutePath,
-        "--target", appTargetJar.get().asFile.absolutePath,
-        "--source", androidTestSourceJar.get().asFile.absolutePath,
-        "--output", outputProguardRules.get().asFile.absolutePath
-    ) + keepRulesArgs.getOrElse(listOf())
+    args = listOf<Pair<String, String?>>(
+        "--keep-rules" to "",
+        "--lib" to androidLib.get().asFile.absolutePath,
+        "--lib" to androidTestLib.orNull?.asFile?.absolutePath,
+        "--target" to appTargetJar.get().asFile.absolutePath,
+        "--source" to androidTestSourceJar.get().asFile.absolutePath,
+        "--output" to outputProguardRules.get().asFile.absolutePath
+    ).map { if (it.second != null) listOf(it.first, it.second) else listOf() }
+        .reduce { acc, any -> acc + any } + keepRulesArgs.getOrElse(listOf())
 
-    println(args)
     super.exec()
   }
 

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperExtension.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperExtension.kt
@@ -89,6 +89,11 @@ public open class KeeperExtension @Inject constructor(objects: ObjectFactory) {
 
   internal val traceReferences: TraceReferences = objects.newInstance()
 
+  /**
+   * Allows to enable the new experimental TraceReferences entry-point,
+   * and optionally specify additional arguments.
+   * @see TraceReferences.arguments
+   */
   public fun traceReferences(action: Action<TraceReferences>) {
     traceReferences.enabled.set(true)
     action.execute(traceReferences)

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperExtension.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperExtension.kt
@@ -61,7 +61,8 @@ public open class KeeperExtension @Inject constructor(objects: ObjectFactory) {
    *
    * Example: `"--map-diagnostics:MissingDefinitionsDiagnostic error info".split(" ")`
    */
-  public val keepRulesArgs: ListProperty<String> = objects.listProperty()
+  public val keepRulesArgs: ListProperty<String> = objects.listProperty<String>()
+    .convention(listOf("--map-diagnostics:MissingDefinitionsDiagnostic", "error", "info"))
 
   /** Emit extra debug information, useful for bug reporting. */
   @Suppress("UnstableApiUsage")

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperExtension.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperExtension.kt
@@ -119,7 +119,7 @@ public abstract class TraceReferences @Inject constructor(objects: ObjectFactory
    * Controls whether or not to use the new experimental TraceReferences entry-point.
    * Default is false but it's automatically enabled if the traceReferences block was used.
    */
-  public val enabled: Property<Boolean> = objects.property<Boolean>().convention(false)
+  internal val enabled: Property<Boolean> = objects.property<Boolean>().convention(false)
 
   /**
    * Optional arguments during the trace-references invocation,

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperExtension.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperExtension.kt
@@ -19,6 +19,7 @@ package com.slack.keeper
 import com.android.builder.model.BuildType
 import com.android.builder.model.ProductFlavor
 import org.gradle.api.Action
+import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
@@ -56,13 +57,17 @@ public open class KeeperExtension @Inject constructor(objects: ObjectFactory) {
    */
   public val r8JvmArgs: ListProperty<String> = objects.listProperty()
 
+  /** Controls whether or not to use the new experimental TraceReferences entry-point. Default is false. */
+  @Suppress("UnstableApiUsage")
+  public val enableTraceReferences: Property<Boolean> = objects.property<Boolean>().convention(false)
+
   /**
-   * Optional arguments for the keep-rules invocation.
+   * Optional arguments for the keep-rules invocation, only considered if [enableTraceReferences] is true.
    *
-   * Example: `"--map-diagnostics:MissingDefinitionsDiagnostic error info".split(" ")`
+   * Default value: `listOf("--map-diagnostics:MissingDefinitionsDiagnostic", "error", "info")`
    */
   public val keepRulesArgs: ListProperty<String> = objects.listProperty<String>()
-    .convention(listOf("--map-diagnostics:MissingDefinitionsDiagnostic", "error", "info"))
+      .convention(listOf("--map-diagnostics:MissingDefinitionsDiagnostic", "error", "info"))
 
   /** Emit extra debug information, useful for bug reporting. */
   @Suppress("UnstableApiUsage")

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperExtension.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperExtension.kt
@@ -120,7 +120,7 @@ public interface VariantFilter {
 public abstract class TraceReferences @Inject constructor(objects: ObjectFactory) {
   /**
    * Controls whether or not to use the new experimental TraceReferences entry-point.
-   * Default is false but it's automatically enabled if the traceReferences block was used.
+   * Default is false but it's automatically enabled if the traceReferences block was invoked.
    */
   internal val enabled: Property<Boolean> = objects.property<Boolean>().convention(false)
 

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperExtension.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperExtension.kt
@@ -131,9 +131,11 @@ public abstract class TraceReferences @Inject constructor(objects: ObjectFactory
 
   /**
    * Optional arguments during the trace-references invocation,
-   * only considered if [isTraceReferencesEnabled] is true.
+   * only considered when [enabled] is true.
    *
    * Default value: `listOf("--map-diagnostics:MissingDefinitionsDiagnostic", "error", "info")`
+   * which is coming from [this discussion](https://issuetracker.google.com/issues/173435379)
+   * with the R8 team.
    */
   public val arguments: ListProperty<String> = objects.listProperty<String>()
           .convention(listOf("--map-diagnostics:MissingDefinitionsDiagnostic", "error", "info"))

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperExtension.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperExtension.kt
@@ -56,6 +56,13 @@ public open class KeeperExtension @Inject constructor(objects: ObjectFactory) {
    */
   public val r8JvmArgs: ListProperty<String> = objects.listProperty()
 
+  /**
+   * Optional arguments for the keep-rules invocation.
+   *
+   * Example: `"--map-diagnostics:MissingDefinitionsDiagnostic error info".split(" ")`
+   */
+  public val keepRulesArgs: ListProperty<String> = objects.listProperty()
+
   /** Emit extra debug information, useful for bug reporting. */
   @Suppress("UnstableApiUsage")
   public val emitDebugInformation: Property<Boolean> = objects.property<Boolean>().convention(false)

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperPlugin.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperPlugin.kt
@@ -88,7 +88,7 @@ public class KeeperPlugin : Plugin<Project> {
 
   internal companion object {
     const val INTERMEDIATES_DIR = "intermediates/keeper"
-    const val PRINTUSES_DEFAULT_VERSION = "2.2.41"
+    const val PRINTUSES_DEFAULT_VERSION = "1.6.53"
     const val TRACE_REFERENCES_DEFAULT_VERSION = "3.0.9-dev"
     const val CONFIGURATION_NAME = "keeperR8"
     private val MIN_GRADLE_VERSION = GradleVersion.version("6.0")

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperPlugin.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperPlugin.kt
@@ -259,12 +259,10 @@ public class KeeperPlugin : Plugin<Project> {
     layout.file(provider {
       val compileSdkVersion = appExtension.compileSdkVersion
         ?: error("No compileSdkVersion found")
-      File("${appExtension.sdkDirectory}/platforms/${compileSdkVersion}/${path}").let {
-        val exists = it.exists()
-        check(!required || exists) {
+      File("${appExtension.sdkDirectory}/platforms/${compileSdkVersion}/${path}").also {
+        check(!required || it.exists()) {
           "No $path found! Expected to find it at: $it"
         }
-        it.takeIf { exists }
       }
     })
 

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperPlugin.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperPlugin.kt
@@ -261,7 +261,7 @@ public class KeeperPlugin : Plugin<Project> {
         ?: error("No compileSdkVersion found")
       File("${appExtension.sdkDirectory}/platforms/${compileSdkVersion}/${path}").let {
         val exists = it.exists()
-        check(required.not() or exists) {
+        check(!required || exists) {
           "No $path found! Expected to find it at: $it"
         }
         it.takeIf { exists }

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperPlugin.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperPlugin.kt
@@ -167,7 +167,7 @@ public class KeeperPlugin : Plugin<Project> {
       isCanBeConsumed = false
       isCanBeResolved = true
       defaultDependencies {
-        val version = when (extension.enableTraceReferences.get()) {
+        val version = when (extension.traceReferences.enabled.get()) {
           false -> PRINTUSES_DEFAULT_VERSION
           true -> TRACE_REFERENCES_DEFAULT_VERSION
         }
@@ -236,8 +236,8 @@ public class KeeperPlugin : Plugin<Project> {
               automaticallyAddR8Repo = extension.automaticR8RepoManagement,
               enableAssertions = extension.enableAssertions,
               extensionJvmArgs = extension.r8JvmArgs,
-              enableTraceReferences = extension.enableTraceReferences,
-              keepRulesArgs = extension.keepRulesArgs,
+              traceReferencesEnabled = extension.traceReferences.enabled,
+              traceReferencesArgs = extension.traceReferences.arguments,
               r8Configuration = r8Configuration
           )
       )

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperPlugin.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperPlugin.kt
@@ -88,7 +88,8 @@ public class KeeperPlugin : Plugin<Project> {
 
   internal companion object {
     const val INTERMEDIATES_DIR = "intermediates/keeper"
-    const val DEFAULT_R8_VERSION = "3.0.5-dev"
+    const val PRINTUSES_DEFAULT_VERSION = "2.2.41"
+    const val TRACE_REFERENCES_DEFAULT_VERSION = "3.0.9-dev"
     const val CONFIGURATION_NAME = "keeperR8"
     private val MIN_GRADLE_VERSION = GradleVersion.version("6.0")
 
@@ -166,7 +167,12 @@ public class KeeperPlugin : Plugin<Project> {
       isCanBeConsumed = false
       isCanBeResolved = true
       defaultDependencies {
-        add(project.dependencies.create("com.android.tools:r8:$DEFAULT_R8_VERSION"))
+        val version = when (extension.enableTraceReferences.get()) {
+          false -> PRINTUSES_DEFAULT_VERSION
+          true -> TRACE_REFERENCES_DEFAULT_VERSION
+        }
+        logger.debug("keeper r8 default version: $version")
+        add(project.dependencies.create("com.android.tools:r8:$version"))
       }
     }
 
@@ -230,6 +236,7 @@ public class KeeperPlugin : Plugin<Project> {
               automaticallyAddR8Repo = extension.automaticR8RepoManagement,
               enableAssertions = extension.enableAssertions,
               extensionJvmArgs = extension.r8JvmArgs,
+              enableTraceReferences = extension.enableTraceReferences,
               keepRulesArgs = extension.keepRulesArgs,
               r8Configuration = r8Configuration
           )

--- a/keeper-gradle-plugin/src/test/kotlin/com/slack/keeper/KeeperFunctionalTest.kt
+++ b/keeper-gradle-plugin/src/test/kotlin/com/slack/keeper/KeeperFunctionalTest.kt
@@ -93,10 +93,13 @@ class KeeperFunctionalTest(private val minifierType: MinifierType) {
   enum class MinifierType(
       val taskName: String,
       val expectedRules: String,
-      vararg val gradleArgs: String
+      val enableR8: Boolean = true,
+      val keeperExtraConfig: KeeperExtraConfig = KeeperExtraConfig.NONE
   ) {
-    R8("R8", EXPECTED_GENERATED_RULES, "-Pandroid.enableR8=true"),
-    PROGUARD("Proguard", EXPECTED_PROGUARD_CONFIG, "-Pandroid.enableR8=false")
+    R8_PRINT_USES("R8", EXPECTED_PRINT_RULES_RULES),
+    R8_TRACE_REFERENCES("Proguard", EXPECTED_TRACE_REFERENCES_CONFIG,
+      keeperExtraConfig = KeeperExtraConfig.TRACE_REFERENCES_ENABLED),
+    PROGUARD("Proguard", EXPECTED_PROGUARD_CONFIG, enableR8 = false)
   }
 
   @Rule
@@ -113,14 +116,14 @@ class KeeperFunctionalTest(private val minifierType: MinifierType) {
   @Test
   fun standard() {
     val (projectDir, proguardConfigOutput) = prepareProject(temporaryFolder,
-        buildGradleFile("staging"))
+        buildGradleFile("staging", keeperExtraConfig = minifierType.keeperExtraConfig))
 
     val result = projectDir.runAsWiredStaging()
 
     // Ensure the expected parameterized minifiers ran
-    assertThat(result.resultOf(
-        KeeperPlugin.interpolateTaskName("ExternalStaging", minifierType.taskName))).isEqualTo(
-        TaskOutcome.SUCCESS)
+    val taskName = KeeperPlugin.interpolateTaskName("ExternalStaging", minifierType.taskName)
+    print("Check $taskName for ${minifierType.taskName}")
+    assertThat(result.resultOf(taskName)).isEqualTo(TaskOutcome.SUCCESS)
     assertThat(result.resultOf(KeeperPlugin.interpolateTaskName("ExternalStagingAndroidTest",
         minifierType.taskName))).isEqualTo(TaskOutcome.SUCCESS)
 
@@ -139,7 +142,7 @@ class KeeperFunctionalTest(private val minifierType: MinifierType) {
     // Assert we correctly generated rules
     val generatedRules = projectDir.generatedChild(
         "inferredExternalStagingAndroidTestKeepRules.pro")
-    assertThat(generatedRules.readText().trim()).isEqualTo(EXPECTED_GENERATED_RULES)
+    assertThat(generatedRules.readText().trim()).isEqualTo(minifierType.expectedRules)
 
     // Finally - verify our rules were included in the final minification execution.
     // Have to compare slightly different strings because proguard's format is a little different
@@ -152,7 +155,7 @@ class KeeperFunctionalTest(private val minifierType: MinifierType) {
   @Test
   fun variantFilter() {
     val (projectDir, _) = prepareProject(temporaryFolder, buildGradleFile("release",
-        sampleVariantFilter = SampleVariantFilter.ONLY_INTERNAL_RELEASE))
+        keeperExtraConfig = KeeperExtraConfig.ONLY_INTERNAL_RELEASE))
 
     val result = runGradle(projectDir, "assembleExternalRelease", "assembleInternalRelease", "-x",
         "lintVitalExternalRelease", "-x", "lintVitalInternalRelease")
@@ -171,7 +174,7 @@ class KeeperFunctionalTest(private val minifierType: MinifierType) {
   fun variantFilterWarning() {
     // internalDebug variant isn't minified, but the variantFilter includes it.
     val (projectDir, _) = prepareProject(temporaryFolder, buildGradleFile("debug",
-        sampleVariantFilter = SampleVariantFilter.ONLY_INTERNAL_DEBUG))
+        keeperExtraConfig = KeeperExtraConfig.ONLY_INTERNAL_DEBUG))
 
     val result = runGradle(projectDir, "assembleInternalDebug")
 
@@ -259,7 +262,7 @@ private fun String.prefixIfNot(prefix: String) =
     if (this.startsWith(prefix)) this else "$prefix$this"
 
 @Language("PROGUARD")
-private val EXPECTED_GENERATED_RULES = """
+private val EXPECTED_PRINT_RULES_RULES = """
   -keep class com.slack.keeper.sample.TestOnlyClass {
     public static void testOnlyMethod();
   }
@@ -267,18 +270,31 @@ private val EXPECTED_GENERATED_RULES = """
     public void testOnlyMethod();
     com.slack.keeper.sample.TestOnlyKotlinClass INSTANCE;
   }
+  -keeppackagenames
+""".trimIndent()
+
+@Language("PROGUARD")
+private val EXPECTED_TRACE_REFERENCES_CONFIG = """
+  -keep class com.slack.keeper.sample.TestOnlyClass {
+      public static void testOnlyMethod();
+  }
+  
+  -keep class com.slack.keeper.sample.TestOnlyKotlinClass {
+      com.slack.keeper.sample.TestOnlyKotlinClass INSTANCE;
+      public void testOnlyMethod();
+  }
 """.trimIndent()
 
 @Language("PROGUARD")
 private val EXPECTED_PROGUARD_CONFIG = """
-    -keep class com.slack.keeper.sample.TestOnlyClass {
-        public static void testOnlyMethod();
-    }
-    
-    -keep class com.slack.keeper.sample.TestOnlyKotlinClass {
-        com.slack.keeper.sample.TestOnlyKotlinClass INSTANCE;
-        public void testOnlyMethod();
-    }
+  -keep class com.slack.keeper.sample.TestOnlyClass {
+      public static void testOnlyMethod();
+  }
+  
+  -keep class com.slack.keeper.sample.TestOnlyKotlinClass {
+      com.slack.keeper.sample.TestOnlyKotlinClass INSTANCE;
+      public void testOnlyMethod();
+  }
 """.trimIndent()
 
 @Language("PROGUARD")
@@ -292,7 +308,7 @@ private val TEST_PROGUARD_RULES = """
   -dontnote **
 """.trimIndent()
 
-enum class SampleVariantFilter(val groovy: String) {
+enum class KeeperExtraConfig(val groovy: String) {
   NONE(""),
   ONLY_INTERNAL_RELEASE(
       """
@@ -307,6 +323,11 @@ enum class SampleVariantFilter(val groovy: String) {
         setIgnore(name != "internalDebug")
       }
       """.trimIndent()
+  ),
+  TRACE_REFERENCES_ENABLED(
+      """
+      traceReferences {}
+      """.trimIndent()
   );
 }
 
@@ -314,7 +335,7 @@ enum class SampleVariantFilter(val groovy: String) {
 private fun buildGradleFile(
     testBuildType: String,
     automaticR8RepoManagement: Boolean = true,
-    sampleVariantFilter: SampleVariantFilter = SampleVariantFilter.NONE,
+    keeperExtraConfig: KeeperExtraConfig = KeeperExtraConfig.NONE,
     emitDebugInformation: Boolean = false,
     extraDependencies: Map<String, String> = emptyMap()
 ): String {
@@ -402,7 +423,7 @@ private fun buildGradleFile(
     emitDebugInformation.set($emitDebugInformation)
     automaticR8RepoManagement.set($automaticR8RepoManagement)
     emitDebugInformation.set($emitDebugInformation)
-    ${sampleVariantFilter.groovy}
+    ${keeperExtraConfig.groovy}
   }
   
   dependencies {

--- a/keeper-gradle-plugin/src/test/kotlin/com/slack/keeper/KeeperFunctionalTest.kt
+++ b/keeper-gradle-plugin/src/test/kotlin/com/slack/keeper/KeeperFunctionalTest.kt
@@ -248,7 +248,7 @@ class KeeperFunctionalTest(private val minifierType: MinifierType) {
         .withProjectDir(projectDir)
         // TODO eventually test with configuration caching enabled
         // https://docs.gradle.org/nightly/userguide/configuration_cache.html#testkit
-        .withArguments("--stacktrace", "-Pandroid.enableR8=${minifierType.isProguard.not()}", *args)
+        .withArguments("--stacktrace", "-Pandroid.enableR8=${!minifierType.isProguard}", *args)
         .withPluginClasspath()
 //        .withDebug(true)
         .build()

--- a/keeper-gradle-plugin/src/test/kotlin/com/slack/keeper/KeeperFunctionalTest.kt
+++ b/keeper-gradle-plugin/src/test/kotlin/com/slack/keeper/KeeperFunctionalTest.kt
@@ -280,8 +280,7 @@ private val EXPECTED_TRACE_REFERENCES_CONFIG: Map<String, List<String>?> = mapOf
 )
 
 @Language("PROGUARD")
-private val EXPECTED_PRINT_RULES_CONFIG =
-  EXPECTED_TRACE_REFERENCES_CONFIG + listOf("-keeppackagenames" to null)
+private val EXPECTED_PRINT_RULES_CONFIG = EXPECTED_TRACE_REFERENCES_CONFIG
 
 private fun indentRules(header: String, content: List<String>?) =
   if (content == null) header else

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -93,11 +93,14 @@ keeper {
   // Example: share proguard rules for L8 (library desugaring).
   enableL8RuleSharing = true
 
-  // Example: enable the new experimental R8 entry-point.
-  enableTraceReferences = true
-
   // Uncomment this line to debug the R8 from a remote instance.
   //r8JvmArgs.addAll(Arrays.asList("-Xdebug", "-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y"))
+
+  // Example: enable the new experimental R8 entry-point.
+  //traceReferences {
+    //enabled.set(true)
+    //arguments.set(Arrays.asList("--map-diagnostics:MissingDefinitionsDiagnostic", "error", "info"))
+  //}
 }
 
 // To speed up testing, we can also eagerly check that the generated rules match what we expect.

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -92,6 +92,11 @@ keeper {
 
   // Example: share proguard rules for L8 (library desugaring).
   enableL8RuleSharing = true
+
+  // Uncomment this line to debug the R8 from a remote instance.
+  //r8JvmArgs.addAll(Arrays.asList("-Xdebug", "-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y"))
+
+  keepRulesArgs.addAll("--map-diagnostics:MissingDefinitionsDiagnostic error info".split(" "))
 }
 
 // To speed up testing, we can also eagerly check that the generated rules match what we expect.

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -115,8 +115,7 @@ if (isCi) {
           String outputRules = outputProguardRules.getAsFile().get().text
           String expectedRules = file("expectedRules.pro").text
           if (outputRules != expectedRules) {
-            println "Invalid rules: " + outputRules
-            throw new IllegalStateException("Rules don't match expected!")
+            throw new IllegalStateException("Rules don't match expected, existing ones:\n$outputRules")
           }
         }
       }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -95,8 +95,6 @@ keeper {
 
   // Uncomment this line to debug the R8 from a remote instance.
   //r8JvmArgs.addAll(Arrays.asList("-Xdebug", "-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y"))
-
-  keepRulesArgs.addAll("--map-diagnostics:MissingDefinitionsDiagnostic error info".split(" "))
 }
 
 // To speed up testing, we can also eagerly check that the generated rules match what we expect.

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -115,6 +115,7 @@ if (isCi) {
           String outputRules = outputProguardRules.getAsFile().get().text
           String expectedRules = file("expectedRules.pro").text
           if (outputRules != expectedRules) {
+            println "Invalid rules: " + outputRules
             throw new IllegalStateException("Rules don't match expected!")
           }
         }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -93,6 +93,9 @@ keeper {
   // Example: share proguard rules for L8 (library desugaring).
   enableL8RuleSharing = true
 
+  // Example: enable the new experimental R8 entry-point.
+  enableTraceReferences = true
+
   // Uncomment this line to debug the R8 from a remote instance.
   //r8JvmArgs.addAll(Arrays.asList("-Xdebug", "-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y"))
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -98,7 +98,6 @@ keeper {
 
   // Example: enable the new experimental R8 entry-point.
   //traceReferences {
-    //enabled.set(true)
     //arguments.set(Arrays.asList("--map-diagnostics:MissingDefinitionsDiagnostic", "error", "info"))
   //}
 }

--- a/sample/expectedRules.pro
+++ b/sample/expectedRules.pro
@@ -18,4 +18,3 @@
 -keep class okio.ByteString$Companion {
   public okio.ByteString encodeUtf8(java.lang.String);
 }
--keeppackagenames 

--- a/sample/expectedRules.pro
+++ b/sample/expectedRules.pro
@@ -18,3 +18,4 @@
 -keep class okio.ByteString$Companion {
   public okio.ByteString encodeUtf8(java.lang.String);
 }
+-keeppackagenames 


### PR DESCRIPTION
This is based on a conversation I had with the R8 team in [this ticket](https://issuetracker.google.com/issues/173435379).

By using this new experimental entry-point, I could solve my rules generation issues and start running my instrumented tests with keeper support.

As you can notice several arguments changed (like --keeprules to --keep-rules) and even for the keeper sample app, I had to rely on "--map-diagnostics:MissingDefinitionsDiagnostic error info" even if I'm not sure it should be used by default or not...

Anyway I hope by opening this PR to facilitate the migration to this new command when @ZacSweers will judge it's the good time to do it 👍 