### PR TITLE
TraceReferences followups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.job }} / JDK ${{ matrix.ci_java_version }} / AGP ${{ matrix.ci_agp_version }}
+    name: ${{ matrix.job }} / JDK ${{ matrix.ci_java_version }} / AGP ${{ matrix.ci_agp_version }} / TraceRefs ${{ matrix.ci_tracerefs }}
     # Use macOS for emulator hardware acceleration
     runs-on: macOS-latest
     timeout-minutes: 30
@@ -22,6 +22,7 @@ jobs:
       matrix:
         ci_java_version: [1.8]
         ci_agp_version: [4.0.0, 4.1.1, 4.2.0-beta02]
+        ci_tracerefs: [true, false]
         job: [instrumentation, plugin]
     steps:
       - name: Checkout
@@ -55,7 +56,7 @@ jobs:
         with:
           # Run connectedCheck with both Proguard and R8.
           # We don't want to wait for the emulator to start/stop twice, so we combine this script into the same step.
-          script: .github/workflows/run_instrumentation_tests.sh ${{ matrix.ci_agp_version }}
+          script: .github/workflows/run_instrumentation_tests.sh ${{ matrix.ci_agp_version }} ${{ matrix.ci_tracerefs }}
           api-level: 29
 
       - name: (Fail-only) Bundle the build report

--- a/.github/workflows/run_instrumentation_tests.sh
+++ b/.github/workflows/run_instrumentation_tests.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-CI_AGP_VERSION=$1
+AGP_VERSION=$1
+ENABLE_TRACEREFS=$1
 
 function printthreads {
   echo "Thread dump"
@@ -14,8 +15,8 @@ echo "Install coreutils" # For gtimeout
 brew install coreutils
 
 # We only run the sample with R8 as proguard infinite loops if we have java 8 libraries on the classpath 🙃
-./gradlew :sample:minifyExternalStagingWithR8 --stacktrace -PkeeperTest.agpVersion="${CI_AGP_VERSION}"
+./gradlew :sample:minifyExternalStagingWithR8 --stacktrace -PkeeperTest.agpVersion="${AGP_VERSION}" -PkeeperTest.enableTraceReferences="${ENABLE_TRACEREFS}"
 # Reclaim memory because Actions OOMs sometimes with having both an emulator and heavy gradle builds going on
 ./gradlew --stop && jps|grep -E 'KotlinCompileDaemon|GradleDaemon'| awk '{print $1}'| xargs kill -9 || true
 # Now proceed, with much of the build being cached up to this point
-gtimeout --signal=SIGINT 10m ./gradlew connectedExternalStagingAndroidTest --stacktrace -PkeeperTest.agpVersion="${CI_AGP_VERSION}"
+gtimeout --signal=SIGINT 10m ./gradlew connectedExternalStagingAndroidTest --stacktrace -PkeeperTest.agpVersion="${AGP_VERSION}" -PkeeperTest.enableTraceReferences="${ENABLE_TRACEREFS}"

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/InferAndroidTestKeepRules.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/InferAndroidTestKeepRules.kt
@@ -176,10 +176,12 @@ public abstract class InferAndroidTestKeepRules : JavaExec() {
               "${KeeperPlugin.INTERMEDIATES_DIR}/inferred${variantName.capitalize(
                   Locale.US)}KeepRules.pro"))
       classpath(r8Configuration)
-      main = when (this.traceReferencesEnabled.get()) {
-        false -> "com.android.tools.r8.PrintUses"
-        true -> "com.android.tools.r8.tracereferences.TraceReferences"
-      }
+      mainClass.set(this.traceReferencesEnabled.map { enabled ->
+        when (enabled) {
+          false -> "com.android.tools.r8.PrintUses"
+          true -> "com.android.tools.r8.tracereferences.TraceReferences"
+        }
+      })
 
       enableAssertionsProperty.set(enableAssertions)
     }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -78,6 +78,12 @@ android {
   testBuildType = "staging"
 }
 
+// Controlled by Keeper CI for testing
+boolean useTraceReferences = providers.gradleProperty("keeperTest.enableTraceReferences")
+    .forUseAtConfigurationTime()
+    .map { Boolean.parseBoolean(it) }
+    .orElse(false)
+
 keeper {
   // Example: Only enable on "externalStaging"
   variantFilter {
@@ -96,10 +102,12 @@ keeper {
   // Uncomment this line to debug the R8 from a remote instance.
   //r8JvmArgs.addAll(Arrays.asList("-Xdebug", "-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y"))
 
-  // Example: enable the new experimental R8 entry-point.
-  //traceReferences {
-    //arguments.set(Arrays.asList("--map-diagnostics:MissingDefinitionsDiagnostic", "error", "info"))
-  //}
+  if (useTraceReferences) {
+    // Enable the new experimental TraceReferences tool.
+    traceReferences {
+      arguments = ["--map-diagnostics:MissingDefinitionsDiagnostic", "error", "info"]
+    }
+  }
 }
 
 // To speed up testing, we can also eagerly check that the generated rules match what we expect.

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -105,6 +105,7 @@ keeper {
   if (useTraceReferences) {
     // Enable the new experimental TraceReferences tool.
     traceReferences {
+      // Don't fail the build if missing definitions are found.
       arguments = ["--map-diagnostics:MissingDefinitionsDiagnostic", "error", "info"]
     }
   }


### PR DESCRIPTION
Followups from #69 (CC @pgreze)
* Use lazy `mainClass` property
* Wire into CI for the sample too