### PR TITLE
Complete L8 support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,7 +145,7 @@ code it is invoking. To work around this, Keeper does two things:
 used APIs. These merged rules are given to the target app `L8DexDesugarLibTask`.
 2. L8 will still, by default, generate a dex file of backported APIs into both the test app and target
 app, which can cause confusing runtime classpath issues due to L8 generating different implementations
-in each app). Keeper works around this by forcing the use of a single dex file in the target app and
+in each app. Keeper works around this by forcing the use of a single dex file in the target app and
 preventing the inclusion of a backport dex file in the test app.
 
 This L8 support is automatically enabled if `android.compileOptions.coreLibraryDesugaringEnabled` is

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -133,20 +133,23 @@ keeper {
 }
 ```
 
-## L8 rule sharing
+## Core Library Desugaring (L8) Support
 
 Library Desugaring (L8) was introduced in Android Gradle Plugin 4.0. To make this work, the R8 task
 will generate proguard rules indicating which `j$` types are used in source, which the `L8DexDesugarLibTask`
 then uses to know which desugared APIs to keep. This approach can have flaws at runtime though, as the
 classpath of the test APK may not have the right `j$` classes available on its classpath to run app
-code it is invoking. To work around this, you can enable rule sharing to make the AndroidTest-specific
-L8 task reuse the same L8-specific rules that the target variant does.
+code it is invoking. To work around this, Keeper does two things:
 
-```groovy
-keeper {
-  enableL8RuleSharing = true
-}
-```
+1. Keeper merges generated L8 rules from both the androidTest and target app to ensure they cover all
+used APIs. These merged rules are given to the target app `L8DexDesugarLibTask`.
+2. L8 will still, by default, generate a dex file of backported APIs into both the test app and target
+app, which can cause confusing runtime classpath issues due to L8 generating different implementations
+in each app). Keeper works around this by forcing the use of a single dex file in the target app and
+preventing the inclusion of a backport dex file in the test app.
+
+This L8 support is automatically enabled if `android.compileOptions.coreLibraryDesugaringEnabled` is
+true in AGP.
 
 ## TraceReferences
 

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperExtension.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperExtension.kt
@@ -16,7 +16,6 @@
 
 package com.slack.keeper
 
-import com.android.build.gradle.internal.tasks.L8DexDesugarLibTask
 import com.android.builder.model.BuildType
 import com.android.builder.model.ProductFlavor
 import org.gradle.api.Action
@@ -27,6 +26,7 @@ import org.gradle.kotlin.dsl.listProperty
 import org.gradle.kotlin.dsl.newInstance
 import org.gradle.kotlin.dsl.property
 import javax.inject.Inject
+import kotlin.DeprecationLevel.ERROR
 
 /** Configuration for the [InferAndroidTestKeepRules]. */
 public open class KeeperExtension @Inject constructor(objects: ObjectFactory) {
@@ -66,25 +66,11 @@ public open class KeeperExtension @Inject constructor(objects: ObjectFactory) {
   @Suppress("UnstableApiUsage")
   public val enableAssertions: Property<Boolean> = objects.property<Boolean>().convention(true)
 
-  /**
-   * Enables L8 rule sharing. By default, L8 will generate separate rules for test app and
-   * androidTest app L8 rules. This can cause problems in minified tests for a couple reasons
-   * though! This tries to resolve these via two steps.
-   *
-   * Issue 1: L8 will try to obfuscate this otherwise and can result in conflicting class names
-   * between the app and test APKs. This is a little confusing because L8 treats "minified" as
-   * "obfuscated" and tries to match. Since we don't care about obfuscating here, we can just
-   * disable it.
-   *
-   * Issue 2: L8 packages `j$` classes into androidTest but doesn't match what's in the target app.
-   * This causes confusion when invoking code in the target app from the androidTest classloader
-   * and it then can't find some expected `j$` classes. To solve this, we feed the the app's
-   * generated `j$` rules in as inputs to the androidTest L8 task's input rules.
-   *
-   * More details can be found here: https://issuetracker.google.com/issues/158018485
-   *
-   * Patches the [L8DexDesugarLibTask].
-   */
+  @Deprecated(
+    message = "Core Library Desugaring (L8) is automatically configured, this does nothing now " +
+      "and will eventually be removed.",
+    level = ERROR
+  )
   public val enableL8RuleSharing: Property<Boolean> = objects.property<Boolean>().convention(false)
 
   internal val traceReferences: TraceReferences = objects.newInstance()

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperPlugin.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperPlugin.kt
@@ -151,7 +151,7 @@ public class KeeperPlugin : Plugin<Project> {
       extension: KeeperExtension
   ) {
     afterEvaluate {
-      if (appExtension.compileOptions.coreLibraryDesugaringEnabled == true) {
+      if (appExtension.compileOptions.isCoreLibraryDesugaringEnabled) {
         appExtension.onApplicableVariants(project, extension) { testVariant, appVariant ->
 
           // First merge the L8 rules into the app's L8 task

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperPlugin.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperPlugin.kt
@@ -151,7 +151,7 @@ public class KeeperPlugin : Plugin<Project> {
       extension: KeeperExtension
   ) {
     afterEvaluate {
-      if (appExtension.compileOptions.coreLibraryDesugaringEnabled) {
+      if (appExtension.compileOptions.coreLibraryDesugaringEnabled == true) {
         appExtension.onApplicableVariants(project, extension) { testVariant, appVariant ->
 
           // First merge the L8 rules into the app's L8 task

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperPlugin.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperPlugin.kt
@@ -95,8 +95,12 @@ public class KeeperPlugin : Plugin<Project> {
     const val CONFIGURATION_NAME = "keeperR8"
     private val MIN_GRADLE_VERSION = GradleVersion.version("6.0")
 
-    fun interpolateR8TaskName(appVariant: String): String {
-      return "minify${appVariant.capitalize(Locale.US)}WithR8"
+    fun interpolateR8TaskName(variantName: String): String {
+      return "minify${variantName.capitalize(Locale.US)}WithR8"
+    }
+
+    fun interpolateL8TaskName(variantName: String): String {
+      return "l8DexDesugarLib${variantName.capitalize(Locale.US)}"
     }
   }
 
@@ -155,7 +159,7 @@ public class KeeperPlugin : Plugin<Project> {
               .flatMap { it.projectOutputKeepRules }
 
           tasks
-              .named<L8DexDesugarLibTask>(interpolateR8TaskName(appVariant.name))
+              .named<L8DexDesugarLibTask>(interpolateL8TaskName(appVariant.name))
               .configure {
                 val taskName = name
                 keepRulesFiles.from(inputFiles)
@@ -202,7 +206,7 @@ public class KeeperPlugin : Plugin<Project> {
 
           // Now clear the outputs from androidTest's L8 task to end with
           tasks
-            .named<L8DexDesugarLibTask>("l8DexDesugarLib${testVariant.name.capitalize(Locale.US)}")
+            .named<L8DexDesugarLibTask>(interpolateL8TaskName(testVariant.name))
             .configure {
               doLast {
                 clearDir(desugarLibDex.asFile.get())

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperPlugin.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperPlugin.kt
@@ -129,7 +129,7 @@ public class KeeperPlugin : Plugin<Project> {
    * can cause problems in minified tests for a couple reasons though! This tries to resolve these
    * via two steps.
    *
-   * Issue 1: L8 will try to obfuscate this otherwise and can result in conflicting class names
+   * Issue 1: L8 will try to minify the backported APIs otherwise and can result in conflicting class names
    * between the app and test APKs. This is a little confusing because L8 treats "minified" as
    * "obfuscated" and tries to match. Since we don't care about obfuscating here, we can just
    * disable it.

--- a/keeper-gradle-plugin/src/test/kotlin/com/slack/keeper/KeeperFunctionalTest.kt
+++ b/keeper-gradle-plugin/src/test/kotlin/com/slack/keeper/KeeperFunctionalTest.kt
@@ -17,7 +17,7 @@
 package com.slack.keeper
 
 import com.google.common.truth.Truth.assertThat
-import com.slack.keeper.KeeperPlugin.Companion.interpolateTaskName
+import com.slack.keeper.KeeperPlugin.Companion.interpolateR8TaskName
 import com.squareup.javapoet.ClassName
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.BuildTask
@@ -120,9 +120,9 @@ class KeeperFunctionalTest(private val minifierType: MinifierType) {
     val result = projectDir.runAsWiredStaging()
 
     // Ensure the expected parameterized minifiers ran
-    assertThat(result.resultOf(interpolateTaskName("ExternalStaging")))
+    assertThat(result.resultOf(interpolateR8TaskName("ExternalStaging")))
         .isEqualTo(TaskOutcome.SUCCESS)
-    assertThat(result.resultOf(interpolateTaskName("ExternalStagingAndroidTest")))
+    assertThat(result.resultOf(interpolateR8TaskName("ExternalStagingAndroidTest")))
         .isEqualTo(TaskOutcome.SUCCESS)
 
     // Assert we correctly packaged app classes

--- a/sample/src/main/kotlin/com/slack/keeper/sample/SampleApplication.java
+++ b/sample/src/main/kotlin/com/slack/keeper/sample/SampleApplication.java
@@ -18,6 +18,9 @@ package com.slack.keeper.sample;
 
 import android.app.Application;
 import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.ResolverStyle;
 
 public class SampleApplication extends Application {
   @Override public void onCreate() {
@@ -26,5 +29,13 @@ public class SampleApplication extends Application {
 
     // This tests that j$ classes produced by L8 are properly kept in the androidTest APK
     System.out.println("Time is " + Instant.now());
+
+    // Regression test for https://github.com/slackhq/keeper/issues/67
+    @SuppressWarnings("unused")
+    DateTimeFormatter formatter = new DateTimeFormatterBuilder()
+        .parseCaseInsensitive()
+        .appendInstant(9)
+        .toFormatter()
+        .withResolverStyle(ResolverStyle.STRICT);
   }
 }


### PR DESCRIPTION
See the configuration.md file and doc on `configureL8` function for full details!

Also resolves #67, which is a nice added layer of validation.