### PR TITLE
Rework artifact inputs

### DIFF
--- a/keeper-gradle-plugin/api/keeper-gradle-plugin.api
+++ b/keeper-gradle-plugin/api/keeper-gradle-plugin.api
@@ -2,7 +2,6 @@ public abstract class com/slack/keeper/AndroidTestVariantClasspathJar : com/slac
 	public fun <init> ()V
 	public final fun createJar ()V
 	public final fun from ([Ljava/lang/Object;)V
-	public abstract fun getAndroidTestArtifactFiles ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getAppJarsFile ()Lorg/gradle/api/file/RegularFileProperty;
 	public abstract fun getArchiveFile ()Lorg/gradle/api/file/RegularFileProperty;
 	public abstract fun getClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
@@ -11,8 +10,10 @@ public abstract class com/slack/keeper/AndroidTestVariantClasspathJar : com/slac
 public abstract class com/slack/keeper/BaseKeeperJarTask : org/gradle/api/DefaultTask {
 	public fun <init> ()V
 	protected final fun diagnostic (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Ljava/io/File;
+	public final fun getArtifactFiles ()Lorg/gradle/api/file/FileCollection;
 	public abstract fun getDiagnosticsOutputDir ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getEmitDebugInfo ()Lorg/gradle/api/provider/Property;
+	public final fun setArtifacts (Lorg/gradle/api/artifacts/ArtifactCollection;)V
 }
 
 public abstract class com/slack/keeper/InferAndroidTestKeepRules : org/gradle/api/tasks/JavaExec {
@@ -76,7 +77,6 @@ public abstract class com/slack/keeper/VariantClasspathJar : com/slack/keeper/Ba
 	public final fun from ([Ljava/lang/Object;)V
 	public abstract fun getAppJarsFile ()Lorg/gradle/api/file/RegularFileProperty;
 	public abstract fun getArchiveFile ()Lorg/gradle/api/file/RegularFileProperty;
-	public abstract fun getArtifactFiles ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 }
 

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/VariantClasspathJar.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/VariantClasspathJar.kt
@@ -21,19 +21,22 @@ package com.slack.keeper
 import com.android.zipflinger.BytesSource
 import com.android.zipflinger.ZipArchive
 import org.gradle.api.DefaultTask
+import org.gradle.api.artifacts.ArtifactCollection
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.PathSensitivity.NONE
-import org.gradle.api.tasks.TaskAction
 import org.gradle.jvm.tasks.Jar
 import java.io.File
 import java.util.zip.Deflater
@@ -44,8 +47,28 @@ public abstract class BaseKeeperJarTask : DefaultTask() {
   @get:Input
   public abstract val emitDebugInfo: Property<Boolean>
 
+  private lateinit var artifacts: ArtifactCollection
+
   @get:OutputDirectory
   public abstract val diagnosticsOutputDir: DirectoryProperty
+
+  /**
+   * This artifact collection is the result of resolving the compilation classpath.
+   */
+  public fun setArtifacts(artifacts: ArtifactCollection) {
+    this.artifacts = artifacts
+  }
+
+  /**
+   * This is the "official" input for wiring task dependencies correctly, but is otherwise
+   * unused. This needs to use [InputFiles] and [PathSensitivity.ABSOLUTE] because the path to the
+   * jars really does matter here. Using [Classpath] is an error, as it looks only at content and
+   * not name or path, and we really do need to know the actual path to the artifact, even if its
+   * contents haven't changed.
+   */
+  @PathSensitive(PathSensitivity.ABSOLUTE)
+  @InputFiles
+  public fun getArtifactFiles(): FileCollection = artifacts.artifactFiles
 
   protected fun diagnostic(fileName: String, body: () -> String): File? {
     return if (emitDebugInfo.get()) {
@@ -69,9 +92,6 @@ public abstract class BaseKeeperJarTask : DefaultTask() {
 @CacheableTask
 public abstract class VariantClasspathJar : BaseKeeperJarTask() {
 
-  @get:Classpath
-  public abstract val artifactFiles: ConfigurableFileCollection
-
   @get:OutputFile
   public abstract val archiveFile: RegularFileProperty
 
@@ -92,7 +112,7 @@ public abstract class VariantClasspathJar : BaseKeeperJarTask() {
     val appClasses = mutableSetOf<String>()
     ZipArchive(archiveFile.asFile.get().toPath()).use { archive ->
       // The runtime classpath (i.e. from dependencies)
-      artifactFiles
+      getArtifactFiles()
           .forEach { jar ->
             appJars.add(jar.canonicalPath)
             archive.extractClassesFrom(jar) {
@@ -132,9 +152,6 @@ public abstract class AndroidTestVariantClasspathJar : BaseKeeperJarTask() {
     val LOG = AndroidTestVariantClasspathJar::class.simpleName!!
   }
 
-  @get:Classpath
-  public abstract val androidTestArtifactFiles: ConfigurableFileCollection
-
   @get:PathSensitive(NONE) // Only care about the contents
   @get:InputFile
   public abstract val appJarsFile: RegularFileProperty
@@ -155,7 +172,7 @@ public abstract class AndroidTestVariantClasspathJar : BaseKeeperJarTask() {
     logger.debug("$LOG: Diffing androidTest jars and app jars")
     val appJars = appJarsFile.get().asFile.useLines { it.toSet() }
 
-    val androidTestClasspath = androidTestArtifactFiles.files
+    val androidTestClasspath = getArtifactFiles()
     diagnostic("jars") {
       androidTestClasspath.sortedBy { it.canonicalPath }
           .joinToString("\n") {

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/VariantClasspathJar.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/VariantClasspathJar.kt
@@ -37,6 +37,7 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.PathSensitivity.NONE
+import org.gradle.api.tasks.TaskAction
 import org.gradle.jvm.tasks.Jar
 import java.io.File
 import java.util.zip.Deflater


### PR DESCRIPTION
Gradle's `@Classpath` annotation seems quite strange and turns out is not actually what we want. This reworks things to explicitly use `ArtifactCollection` + absolute paths for caching. This is important because we care about the jar locations even if the contents are the same because we need to read their contents during task exec. This is a nicer solution than just disabling caching entirely as it will still allow caching on the same machine.