### PR TITLE
Using TCK Tested JDK builds of OpenJDK  in GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false # We want to see all results
       matrix:
-        java: ['11']
+        java: [ '11.0.3', '11' ]
         agp: ['7.0.0', '7.1.0-alpha05']
         tracerefs: [true, false]
         job: ['instrumentation', 'plugin']
@@ -44,7 +44,7 @@ jobs:
       - name: Install JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'zulu'
           java-version: ${{ matrix.java }}
 
       - name: Test plugin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false # We want to see all results
       matrix:
-        java: [ '11.0.3', '11' ]
+        java: [ '11' ]
         agp: ['7.0.0', '7.1.0-alpha05']
         tracerefs: [true, false]
         job: ['instrumentation', 'plugin']


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021 (https://adoptopenjdk.net). Switching the distribution to Azul Zulu. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. 

Please see more details at Foojay.io:
https://foojay.io/today/github-actions-with-java-part-2/