### PR TITLE
Update default R8 to 8.2.38

### DIFF
--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperPlugin.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperPlugin.kt
@@ -92,7 +92,7 @@ public class KeeperPlugin : Plugin<Project> {
 
   internal companion object {
     const val INTERMEDIATES_DIR = "intermediates/keeper"
-    const val TRACE_REFERENCES_DEFAULT_VERSION = "8.1.56"
+    const val TRACE_REFERENCES_DEFAULT_VERSION = "8.2.38"
     const val CONFIGURATION_NAME = "keeperR8"
     private val MIN_GRADLE_VERSION = GradleVersion.version("8.0")
 


### PR DESCRIPTION
Tested with `./gradlew build` 

`Contributing` doc mention signing CLA: https://slackhq.github.io/keeper/contributing/#requirements
but the link doesn't work:
![image](https://github.com/slackhq/keeper/assets/3951580/32d44905-0c15-48e1-8705-7be5ac88c18b)
