### PR TITLE
Fix usage of plugin in Windows

### DIFF
--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/ZipFlingerExt.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/ZipFlingerExt.kt
@@ -30,7 +30,7 @@ internal fun File.classesSequence(): Sequence<Pair<String, File>> {
     .filter { it.extension == "class" }
     .filterNot { "META-INF" in it.name }
     .sortedBy { it.invariantSeparatorsPath }
-    .map { it.absolutePath.removePrefix(prefix).removePrefix("/") to it }
+    .map { it.absolutePath.removePrefix(prefix).removePrefix(File.separator).replace(File.separator, "/") to it }
 }
 
 /** Extracts classes from the target [jar] into this archive. */


### PR DESCRIPTION
Solves: https://github.com/slackhq/keeper/issues/124
Tested on Windows 11 and CircleCI's docker image for Android builds (cimg/android:2024.04.1-ndk).