### PR TITLE
Multiplatform CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,13 @@ jobs:
         if: matrix.job == 'instrumentation'
         run: ./gradlew :sample:minifyExternalStagingWithR8 validateL8 --stacktrace
 
+      - name: Enable KVM group perms
+        if: matrix.job == 'instrumentation' && matrix.os == 'ubuntu-latest'
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       # TODO AVD caching disabled due to https://github.com/ReactiveCircus/android-emulator-runner/issues/278
 #      - name: AVD cache
 #        uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ on:
   # Always run on PRs
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   # Test on API 30 because that's the first version with ATDs
   API_LEVEL: '30'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,14 @@ env:
 
 jobs:
   build:
-    name: ${{ matrix.job }} / AGP ${{ matrix.agp }}
+    name: ${{ matrix.job }} / AGP ${{ matrix.agp }} / OS ${{ matrix.os }}
     # Use macOS for emulator hardware acceleration
-    runs-on: 'ubuntu-latest'
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
       fail-fast: false # We want to see all results
       matrix:
+        os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest']
         agp: ['8.4.0', '8.5.0-alpha08']
         job: ['instrumentation', 'plugin']
     env:
@@ -66,7 +67,7 @@ jobs:
 #      - name: AVD cache
 #        uses: actions/cache@v3
 #        id: avd-cache
-#        if: matrix.job == 'instrumentation'
+#        if: matrix.job == 'instrumentation' && matrix.os == 'ubuntu-latest'
 #        with:
 #          path: |
 #            ~/.android/avd/*
@@ -75,7 +76,7 @@ jobs:
 #          key: avd-${{ env.API_LEVEL }}-${{ env.AVD_TARGET }}
 #
 #      - name: Create AVD and generate snapshot for caching
-#        if: matrix.job == 'instrumentation' && steps.avd-cache.outputs.cache-hit != 'true'
+#        if: matrix.job == 'instrumentation' && matrix.os == 'ubuntu-latest' && steps.avd-cache.outputs.cache-hit != 'true'
 #        uses: reactivecircus/android-emulator-runner@v2
 #        with:
 #          api-level: ${{ env.API_LEVEL }}
@@ -88,7 +89,7 @@ jobs:
 #          script: echo "Generated AVD snapshot for caching."
 
       - name: Run instrumentation tests
-        if: matrix.job == 'instrumentation'
+        if: matrix.job == 'instrumentation' && matrix.os == 'ubuntu-latest'
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ env.API_LEVEL }}
@@ -109,16 +110,14 @@ jobs:
             adb uninstall com.slack.keeper.sample || true
             adb uninstall com.slack.keeper.sample.androidTest || true
 
-      - name: (Fail-only) Bundle the build report
-        if: failure()
-        run: find . -type d -name 'reports' | zip -@ -r build-reports.zip
-
-      - name: (Fail-only) Upload the build report
+      - name: (Fail-only) Upload the build reports
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: error-report-${{ matrix.job }}-${{ matrix.agp }}
-          path: build-reports.zip
+          name: error-report-${{ matrix.job }}-${{ matrix.agp }}-${{ matrix.os }}
+          path: |
+            keeper-gradle-plugin/build/reports
+            sample/build/reports
 
   publish-snapshots:
     name: Publish Snapshots


### PR DESCRIPTION

Hi there - thanks for this module, it's helped us over at [Anki-Android](https://github.com/ankidroid/Anki-Android)

Here's a patch that expands the CI workflow to be multiplatform so that validation happens on windows, macOS and linux

This should surface the windows problem that #147 intends to fix and help protect against regression in the area

I threw in a couple tiny workflow fixes apart from the matrix dimension add for operating system, each in separate commit so they may be considered cleanly in diff view

- I added concurrency control so that doing a fresh push will kill any old runs on the same github ref and start the new one (helps when testing a PR that does CI!)
- I added the required KVM permissions for the android emulator to get hardware acceleration, this should make those matrix jobs a lot less flaky and they only take 5mins now: https://github.com/reactivecircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners

The main commit is to add the dimension to the job matrix for runner OS of course. I'll make some comments on the diff that explain anything that seems subtle so it's not subtle and is easier to review