### PR TITLE
Fixes `AGP9` breaking changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false # We want to see all results
       matrix:
         os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest']
-        agp: ['8.5.0', '8.6.0-alpha08']
+        agp: ['8.5.0', '9.0.0']
         job: ['instrumentation', 'plugin']
     env:
       DEP_OVERRIDE_agp: ${{ matrix.agp }}
@@ -42,7 +42,7 @@ jobs:
         uses: gradle/actions/wrapper-validation@v3
 
       - name: Install JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '21'
@@ -98,7 +98,7 @@ jobs:
 
       - name: (Fail-only) Upload the build reports
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v6
         with:
           name: error-report-${{ matrix.job }}-${{ matrix.agp }}-${{ matrix.os }}
           path: |
@@ -115,7 +115,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '21'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-agp = "8.5.0"
+agp = "9.0.0"
 androidx-test = "1.6.1"
-kotlin = "1.9.24"
+kotlin = "2.3.0"
 gjf = "1.22.0"
 ktfmt = "0.51"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperPlugin.kt
+++ b/keeper-gradle-plugin/src/main/java/com/slack/keeper/KeeperPlugin.kt
@@ -18,12 +18,12 @@
 package com.slack.keeper
 
 import com.android.build.api.artifact.ScopedArtifact
+import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.variant.AndroidTest
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.ApplicationVariant
 import com.android.build.api.variant.Component
 import com.android.build.api.variant.ScopedArtifacts
-import com.android.build.gradle.AppExtension
 import com.android.build.gradle.internal.publishing.AndroidArtifacts
 import com.android.build.gradle.internal.publishing.AndroidArtifacts.ArtifactType
 import com.android.build.gradle.internal.tasks.L8DexDesugarLibTask
@@ -106,7 +106,7 @@ public class KeeperPlugin : Plugin<Project> {
       "Keeper requires Gradle ${MIN_GRADLE_VERSION.version} or later."
     }
     project.pluginManager.withPlugin("com.android.application") {
-      val appExtension = project.extensions.getByType(AppExtension::class.java)
+      val appExtension = project.extensions.getByType(ApplicationExtension::class.java)
       val appComponentsExtension =
         project.extensions.getByType(ApplicationAndroidComponentsExtension::class.java)
       val extension = project.extensions.create("keeper", KeeperExtension::class.java)
@@ -142,7 +142,7 @@ public class KeeperPlugin : Plugin<Project> {
    */
   private fun configureL8(
     project: Project,
-    appExtension: AppExtension,
+    appExtension: ApplicationExtension,
     appComponentsExtension: ApplicationAndroidComponentsExtension,
     extension: KeeperExtension,
   ) {
@@ -214,7 +214,7 @@ public class KeeperPlugin : Plugin<Project> {
   }
 
   private fun Project.configureKeepRulesGeneration(
-    appExtension: AppExtension,
+    appExtension: ApplicationExtension,
     appComponentsExtension: ApplicationAndroidComponentsExtension,
     extension: KeeperExtension,
   ) {
@@ -300,15 +300,15 @@ public class KeeperPlugin : Plugin<Project> {
   }
 
   private fun resolveAndroidEmbeddedJar(
-    appExtension: AppExtension,
+    appExtension: ApplicationExtension,
     appComponentsExtension: ApplicationAndroidComponentsExtension,
     path: String,
     checkIfExisting: Boolean,
   ): File {
-    val compileSdkVersion = appExtension.compileSdkVersion ?: error("No compileSdkVersion found")
+    val compileSdkVersion = appExtension.compileSdk ?: error("No compileSdkVersion found")
     val file =
       File(
-        "${appComponentsExtension.sdkComponents.sdkDirectory.get().asFile}/platforms/$compileSdkVersion/$path"
+        "${appComponentsExtension.sdkComponents.sdkDirectory.get().asFile}/platforms/android-$compileSdkVersion/$path"
       )
     check(!checkIfExisting || file.exists()) {
       "No $path found! Expected to find it at: ${file.absolutePath}"

--- a/keeper-gradle-plugin/src/test/kotlin/com/slack/keeper/KeeperFunctionalTest.kt
+++ b/keeper-gradle-plugin/src/test/kotlin/com/slack/keeper/KeeperFunctionalTest.kt
@@ -400,7 +400,6 @@ private fun buildGradleFile(
 
   plugins {
     id 'com.android.application' version '8.4.0'
-    id 'org.jetbrains.kotlin.android' version '1.9.23'
     id 'com.slack.keeper'
   }
 
@@ -430,7 +429,7 @@ private fun buildGradleFile(
       release {
         minifyEnabled = true
         signingConfig = buildTypes.debug.signingConfig
-        proguardFiles getDefaultProguardFile('proguard-android.txt'), 'testconfiguration.pro'
+        proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'testconfiguration.pro'
         testProguardFiles('proguard-test-rules.pro')
       }
       staging {

--- a/sample-libraries/a/build.gradle
+++ b/sample-libraries/a/build.gradle
@@ -16,7 +16,6 @@
 
 plugins {
   id 'com.android.library'
-  id 'org.jetbrains.kotlin.android'
 }
 
 android {

--- a/sample-libraries/b/build.gradle
+++ b/sample-libraries/b/build.gradle
@@ -16,7 +16,6 @@
 
 plugins {
   id 'com.android.library'
-  id 'org.jetbrains.kotlin.android'
 }
 
 android {

--- a/sample-libraries/test-only-android/build.gradle
+++ b/sample-libraries/test-only-android/build.gradle
@@ -16,7 +16,6 @@
 
 plugins {
   id 'com.android.library'
-  id 'org.jetbrains.kotlin.android'
 }
 
 android {

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -27,12 +27,11 @@ buildscript {
 
 plugins {
   id("com.android.application")
-  id("org.jetbrains.kotlin.android")
   id("com.slack.keeper")
 }
 
 android {
-  compileSdk = 33
+  compileSdk = 34
   namespace = "com.slack.keeper.sample"
 
   defaultConfig {
@@ -75,7 +74,7 @@ android {
     }
   }
 
-  flavorDimensionList.add("environment")
+  flavorDimensions.add("environment")
   productFlavors {
     create("internal") {
       dimension = "environment"


### PR DESCRIPTION
Introduces support for `AGP9`, fixing its breaking changes:
- Bumps `setup-java` and `upload-artifact` actions (required by GHA)
- Bumps `Gradle` to `9.3.0` (min required is `9.1.0`)
- Bumps `Kotlin` to `2.3.0` (requires `kotlin-metadata-2.2.0`)
- Replaces gone `AppExtension` with `ApplicationExtension`
- Removes `org.jetbrains.kotlin.android` from all the examples
- Bumps Android SDK to `34` in samples

Fixes #152

CI checks (on fork):
[![CI](https://github.com/gmazzo/slackhq-keeper/actions/workflows/ci.yml/badge.svg)](https://github.com/gmazzo/slackhq-keeper/actions/workflows/ci.yml)